### PR TITLE
WIP: solr load checks

### DIFF
--- a/OWLTools-Solr/src/main/java/owltools/solrj/FlexSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/FlexSolrDocumentLoader.java
@@ -20,7 +20,7 @@ public class FlexSolrDocumentLoader extends AbstractSolrLoader {
 
 	private static Logger LOG = Logger.getLogger(FlexSolrDocumentLoader.class);
 	private FlexCollection collection = null;
-	int doc_limit_trigger = 1000; // the number of documents to add before pushing out to solr
+	private int doc_limit_trigger = 1000; // the number of documents to add before pushing out to solr
 	int current_doc_number;
 
 	public FlexSolrDocumentLoader(String url, FlexCollection c) throws MalformedURLException {
@@ -76,4 +76,14 @@ public class FlexSolrDocumentLoader extends AbstractSolrLoader {
 		
 		return cls_doc;
 	}
+
+    /**
+     * @return the current_doc_number
+     */
+    public int getCurrentDocNumber() {
+        return current_doc_number;
+    }
+
+  	
+	
 }


### PR DESCRIPTION
Do some very preliminary pre and post load checks for ontologies.
While not a guarantee, it is an extra guard.

 - check min classes
 - check for null ontologies

null ontologies may sometimes happen when an import IRI does not match the imported ontology IRI
See https://github.com/geneontology/noctua/issues/411#issuecomment-293360250