### PR TITLE
Ensure OWLThing and OWLNothing are excluded from loads -

### DIFF
--- a/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperBasic.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperBasic.java
@@ -396,6 +396,8 @@ public class OWLGraphWrapperBasic {
 			obs.addAll(o.getIndividualsInSignature());
 			obs.addAll(o.getObjectPropertiesInSignature());
 		}
+        obs.remove(getDataFactory().getOWLThing());
+        obs.remove(getDataFactory().getOWLNothing());
 		return obs;
 	}
 

--- a/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
+++ b/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
@@ -69,6 +69,7 @@ import owltools.solrj.OntologyGeneralSolrDocumentLoader;
 import owltools.solrj.OptimizeSolrDocumentLoader;
 import owltools.solrj.PANTHERGeneralSolrDocumentLoader;
 import owltools.solrj.PANTHERSolrDocumentLoader;
+import owltools.solrj.loader.MockFlexSolrDocumentLoader;
 import owltools.solrj.loader.MockGafSolrDocumentLoader;
 import owltools.yaml.golrconfig.ConfigManager;
 import owltools.yaml.golrconfig.SolrSchemaXMLWriter;
@@ -309,10 +310,19 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		LOG.info("Assembling FlexCollection...");
 		FlexCollection flex = new FlexCollection(aconf, g);
 		
+        boolean isMock = false;
 		int nClasses = 0;
 		// Actual ontology class loading.
 		try {
-			FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader(url, flex);
+		    FlexSolrDocumentLoader loader;
+	        if (url.equals("mock")) {
+	            loader = new MockFlexSolrDocumentLoader(flex);
+	            isMock = true;
+	        }
+	        else {
+	            loader = new FlexSolrDocumentLoader(url, flex);
+	        }
+		    
 			LOG.info("Trying ontology flex load.");
 			loader.load();
 			
@@ -370,6 +380,13 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 					LOG.info("Failed to get match for version of: " + ont_id + "!");
 				}
 				optionallyLogLoad("ontology", ont_id, ont_version);
+				
+		        if (isMock) {
+		            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		            String json = gson.toJson(((MockFlexSolrDocumentLoader) loader).getDocumentCollection());
+		            System.out.println(json);
+		        }
+
 			}
 		} catch (SolrServerException e) {
 			LOG.info("Ontology load at: " + url + " failed!");

--- a/OWLTools-Solr/src/main/java/owltools/flex/FlexCollection.java
+++ b/OWLTools-Solr/src/main/java/owltools/flex/FlexCollection.java
@@ -3,10 +3,12 @@ package owltools.flex;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -222,7 +224,11 @@ public class FlexCollection implements Iterable<FlexDocument> {
 	@Override
 	public Iterator<FlexDocument> iterator() {
 		final StopWatch timer = new StopWatch();
-		Set<OWLObject> allOWLObjects = graph.getAllOWLObjects();
+		Set<OWLObject> blacklist = new HashSet<>();
+        blacklist.add(graph.getDataFactory().getOWLThing());
+        blacklist.add(graph.getDataFactory().getOWLNothing());
+		Set<OWLObject> allOWLObjects = 
+		        graph.getAllOWLObjects().stream().filter(x -> !blacklist.contains(x)).collect(Collectors.toSet());
 		final int totalCount = allOWLObjects.size();
 		timer.start();
 		final Iterator<OWLObject> objectIterator = allOWLObjects.iterator();

--- a/OWLTools-Solr/src/main/java/owltools/solrj/loader/MockFlexSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/loader/MockFlexSolrDocumentLoader.java
@@ -1,0 +1,31 @@
+package owltools.solrj.loader;
+
+import java.net.MalformedURLException;
+
+import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.common.SolrInputDocument;
+
+import owltools.flex.FlexCollection;
+import owltools.solrj.FlexSolrDocumentLoader;
+
+public class MockFlexSolrDocumentLoader extends FlexSolrDocumentLoader implements MockSolrDocumentLoader {
+    
+    public MockFlexSolrDocumentLoader(FlexCollection c) throws MalformedURLException {
+        super((SolrServer)null, c);
+    }
+   
+    final MockSolrDocumentCollection documentCollection = new MockSolrDocumentCollection();
+    @Override
+    public void add(SolrInputDocument doc) {
+        documentCollection.add(doc);
+    }
+    
+    /**
+     * @return the result
+     */
+    public MockSolrDocumentCollection getDocumentCollection() {
+        return documentCollection;
+    }
+    
+   
+}

--- a/OWLTools-Solr/src/test/java/owltools/solrj/loader/MockFlexSolrDocumentLoaderTest.java
+++ b/OWLTools-Solr/src/test/java/owltools/solrj/loader/MockFlexSolrDocumentLoaderTest.java
@@ -1,0 +1,80 @@
+package owltools.solrj.loader;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.semanticweb.elk.owlapi.ElkReasonerFactory;
+import org.semanticweb.owlapi.model.OWLOntology;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import owltools.flex.FlexCollection;
+import owltools.graph.OWLGraphWrapper;
+import owltools.io.ParserWrapper;
+import owltools.yaml.golrconfig.ConfigManager;
+
+public class MockFlexSolrDocumentLoaderTest {
+
+    private ConfigManager aconf = null;
+
+    public List<Map<String, Object>> mockLoad(String path) throws Exception {
+ 
+        aconf = new ConfigManager();
+        aconf.add("src/test/resources/test-ont-config.yaml");
+
+        ParserWrapper pw = new ParserWrapper();
+        OWLOntology testOwl = pw.parse(new File(path).getCanonicalPath());
+        final OWLGraphWrapper g = new OWLGraphWrapper(testOwl);
+        FlexCollection flex = new FlexCollection(aconf, g);
+
+        ElkReasonerFactory rf = new ElkReasonerFactory();
+
+        MockFlexSolrDocumentLoader l = new MockFlexSolrDocumentLoader(flex);
+        l.load();
+
+
+        List<Map<String, Object>> docs = l.getDocumentCollection().getDocuments();
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        for (Map<String, Object> doc : docs) {
+            String json = gson.toJson(doc);
+            System.out.println(json);
+
+        }    
+        return docs;
+    }
+    
+    @Test
+    public void testMini() throws Exception {
+        
+        List<Map<String, Object>> docs = mockLoad("src/test/resources/not_bioentity_closure/mini-test.obo");
+        assertEquals(10, docs.size());
+        for (Map<String, Object> doc : docs) {
+            assertTrue(checkDocForFilteredClasses(doc));
+        }
+ 
+    }
+    
+    @Test
+    public void testFilterOwlNothing() throws Exception {
+        
+        List<Map<String, Object>> docs = mockLoad("src/test/resources/with-nothing.owl");
+        assertEquals(2, docs.size());
+        for (Map<String, Object> doc : docs) {
+            assertTrue(checkDocForFilteredClasses(doc));
+        }
+ 
+    }
+    
+    // TODO - provide more extensive tests
+    private boolean checkDocForFilteredClasses(Map<String, Object> doc) {
+        Object tg = doc.get("topology_graph_json");
+        System.out.println("TESTING: "+tg.toString());
+        return !tg.toString().contains("Thing") && !tg.toString().contains("Nothing");
+    }
+}

--- a/OWLTools-Solr/src/test/resources/with-nothing.owl
+++ b/OWLTools-Solr/src/test/resources/with-nothing.owl
@@ -1,0 +1,19 @@
+Prefix: GO: <http://purl.obolibrary.org/obo/GO_>
+Ontology: <http://purl.obolibrary.org/obo/go/nothing-test>
+
+##
+
+Class: owl:Thing
+
+Class: GO:0000001
+  SubClassOf: owl:Thing
+  Annotations: rdfs:label "t1"
+
+Class: GO:0000002
+  SubClassOf: owl:Thing
+  Annotations: rdfs:label "t1"
+  SubClassOf: GO:0000001
+
+Class: owl:Nothing
+  SubClassOf: GO:0000001
+  SubClassOf: GO:0000002


### PR DESCRIPTION
as both obejcts, and in topology graphs.

As a byproduct of this fix, we also have better mock testing for solr loading
Fixes https://github.com/geneontology/amigo/issues/428