### PR TITLE
DO NOT MERGE YET: Upgrade to solr6: DO NOT MERGE YET

### DIFF
--- a/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
+++ b/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
@@ -22,9 +22,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.CommonsHttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.SolrException;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.IRI;
@@ -207,7 +207,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		String url = sortOutSolrURL(globalSolrURL);				
 
 		// Wipe out the solr index at url.
-		SolrServer server = new CommonsHttpSolrServer(url);
+		SolrClient server = new HttpSolrClient(url);
 		try {
 			server.deleteByQuery("*:*");
 			server.commit();

--- a/OWLTools-Solr/pom.xml
+++ b/OWLTools-Solr/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<artifactId>solr-solrj</artifactId>
 			<groupId>org.apache.solr</groupId>
-			<version>3.6.0</version>
+			<version>6.5.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>

--- a/OWLTools-Solr/src/main/java/owltools/solrj/AbstractSolrLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/AbstractSolrLoader.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.CommonsHttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.SolrInputDocument;
 import org.semanticweb.owlapi.model.OWLObject;
 
@@ -29,7 +29,9 @@ public abstract class AbstractSolrLoader {
 	
 	private static Logger LOG = Logger.getLogger(AbstractSolrLoader.class);
 	
-    protected SolrServer server;
+	// note: SolrServer was deprecated and finally removed in solr6.
+	// we replace the class usage TODO - change variable name
+    protected SolrClient server;
     
     private Collection<SolrInputDocument> docs = new ArrayList<SolrInputDocument>();
 
@@ -47,7 +49,7 @@ public abstract class AbstractSolrLoader {
 		this.graph = graph;
 	}
 
-	public AbstractSolrLoader(SolrServer server) {
+	public AbstractSolrLoader(SolrClient server) {
 		super();
 		this.server = server;
 	}
@@ -57,9 +59,10 @@ public abstract class AbstractSolrLoader {
 		
 	}
 	
-	public static final SolrServer createDefaultServer(String url) throws MalformedURLException {
+	public static final SolrClient createDefaultServer(String url) throws MalformedURLException {
 		LOG.info("Server at: " + url);
-		return new CommonsHttpSolrServer(url);
+		// TODO: https://mycore.atlassian.net/browse/DBT-77 use HttpSolrClient.Builder
+		return new HttpSolrClient(url);
 	}
 
 	/**

--- a/OWLTools-Solr/src/main/java/owltools/solrj/FlexSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/FlexSolrDocumentLoader.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 
 import org.apache.log4j.Logger;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 
@@ -29,7 +29,7 @@ public class FlexSolrDocumentLoader extends AbstractSolrLoader {
 		current_doc_number = 0;
 	}
 	
-	protected FlexSolrDocumentLoader(SolrServer server, FlexCollection c) {
+	protected FlexSolrDocumentLoader(SolrClient server, FlexCollection c) {
 		super(server);
 		collection = c;
 		current_doc_number = 0;

--- a/OWLTools-Solr/src/main/java/owltools/solrj/GafSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/GafSolrDocumentLoader.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.semanticweb.owlapi.model.OWLClass;
@@ -65,7 +65,7 @@ public class GafSolrDocumentLoader extends AbstractSolrLoader {
 	 * @param server
 	 * @param triggerLimit
 	 */
-	protected GafSolrDocumentLoader(SolrServer server, int triggerLimit) {
+	protected GafSolrDocumentLoader(SolrClient server, int triggerLimit) {
 		super(server);
 		this.doc_limit_trigger = triggerLimit;
 	}

--- a/OWLTools-Solr/src/main/java/owltools/solrj/ModelAnnotationSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/ModelAnnotationSolrDocumentLoader.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.obolibrary.obo2owl.Obo2OWLConstants;
@@ -92,7 +92,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		this(createDefaultServer(golrUrl), model, r, modelUrl, modelFilter, skipDeprecatedModels, skipTemplateModels);
 	}
 	
-	public ModelAnnotationSolrDocumentLoader(SolrServer server, OWLOntology model, OWLReasoner r, String modelUrl, 
+	public ModelAnnotationSolrDocumentLoader(SolrClient server, OWLOntology model, OWLReasoner r, String modelUrl, 
 			Set<String> modelFilter, boolean skipDeprecatedModels, boolean skipTemplateModels) {
 		super(server);
 		this.model = model;

--- a/OWLTools-Solr/src/main/java/owltools/solrj/loader/MockFlexSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/loader/MockFlexSolrDocumentLoader.java
@@ -2,8 +2,9 @@ package owltools.solrj.loader;
 
 import java.net.MalformedURLException;
 
-import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.client.solrj.SolrClient;
+
 
 import owltools.flex.FlexCollection;
 import owltools.solrj.FlexSolrDocumentLoader;
@@ -11,7 +12,7 @@ import owltools.solrj.FlexSolrDocumentLoader;
 public class MockFlexSolrDocumentLoader extends FlexSolrDocumentLoader implements MockSolrDocumentLoader {
     
     public MockFlexSolrDocumentLoader(FlexCollection c) throws MalformedURLException {
-        super((SolrServer)null, c);
+        super((SolrClient)null, c);
     }
    
     final MockSolrDocumentCollection documentCollection = new MockSolrDocumentCollection();

--- a/OWLTools-Solr/src/test/java/owltools/solrj/AllOntologyLoaderIntegrationRunner.java
+++ b/OWLTools-Solr/src/test/java/owltools/solrj/AllOntologyLoaderIntegrationRunner.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 import java.util.Properties;
 
 import org.apache.commons.lang3.time.StopWatch;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.AfterClass;
@@ -101,7 +101,7 @@ public class AllOntologyLoaderIntegrationRunner {
 		
 		StopWatch watch = new StopWatch();
 		watch.start();
-		FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader((SolrServer)null, c) {
+		FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader((SolrClient)null, c) {
 
 			@Override
 			protected void addToServer(Collection<SolrInputDocument> docs)

--- a/OWLTools-Solr/src/test/java/owltools/solrj/FullTaxonIntegrationRunner.java
+++ b/OWLTools-Solr/src/test/java/owltools/solrj/FullTaxonIntegrationRunner.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Properties;
 
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.AfterClass;
@@ -58,7 +58,7 @@ public class FullTaxonIntegrationRunner {
 		GafSolrDocumentLoaderIntegrationRunner.gc();
 		GafSolrDocumentLoaderIntegrationRunner.printMemoryStats();
 		
-		FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader((SolrServer)null, c) {
+		FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader((SolrClient)null, c) {
 
 			@Override
 			protected void addToServer(Collection<SolrInputDocument> docs)

--- a/OWLTools-Solr/src/test/java/owltools/solrj/GoLoaderIntegrationRunner.java
+++ b/OWLTools-Solr/src/test/java/owltools/solrj/GoLoaderIntegrationRunner.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 import java.util.Properties;
 
 import org.apache.commons.lang3.time.StopWatch;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.AfterClass;
@@ -64,7 +64,7 @@ public class GoLoaderIntegrationRunner {
 		GafSolrDocumentLoaderIntegrationRunner.gc();
 		GafSolrDocumentLoaderIntegrationRunner.printMemoryStats();
 		
-		FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader((SolrServer)null, c) {
+		FlexSolrDocumentLoader loader = new FlexSolrDocumentLoader((SolrClient)null, c) {
 
 			@Override
 			protected void addToServer(Collection<SolrInputDocument> docs)

--- a/OWLTools-Solr/src/test/java/owltools/solrj/OntologyAndGafLoaderIntegrationRunner.java
+++ b/OWLTools-Solr/src/test/java/owltools/solrj/OntologyAndGafLoaderIntegrationRunner.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Properties;
 
 import org.apache.commons.lang3.time.StopWatch;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.AfterClass;
@@ -122,7 +122,7 @@ public class OntologyAndGafLoaderIntegrationRunner {
 
 			final StopWatch ontologyWatch = new StopWatch();
 			ontologyWatch.start();
-			final FlexSolrDocumentLoader ontologyLoader = new FlexSolrDocumentLoader((SolrServer)null, c) {
+			final FlexSolrDocumentLoader ontologyLoader = new FlexSolrDocumentLoader((SolrClient)null, c) {
 
 				@Override
 				protected void addToServer(Collection<SolrInputDocument> docs)


### PR DESCRIPTION
Fixes #194

Still to do, but can be punted:

 - variable names may still say 'server' even though solrj changed class name from Server to Client
 - We use HttpSolrClient which is deprecated; change to builder

cc @kltm 