### PR TITLE
Changing solr loading commands to fail fast if solr exceptions are th…

### DIFF
--- a/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
+++ b/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
@@ -202,29 +202,24 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 */
 	@SuppressWarnings("deprecation")
 	@CLIMethod("--solr-purge")
-	public void purgeSolr(Opts opts) throws Exception {
+	public void purgeSolr(Opts opts) throws Exception  {
 
 		// Check to see if the global url has been set.
 		String url = sortOutSolrURL(globalSolrURL);				
 
 		// Wipe out the solr index at url.
 		SolrServer server = new CommonsHttpSolrServer(url);
-		try {
-			server.deleteByQuery("*:*");
-			server.commit();
-		
-			// Probably worked, so let's destroy the log if there is one.
-			if( globalSolrLogFile != null && globalSolrLogFile.exists() ){
-				boolean yes_p = globalSolrLogFile.delete();
-				if( yes_p ){
-					LOG.info("Deleted GOlr load log file.");
-				}else{
-					// Nothing there, doing nothing.
-				}
-			}
-		} catch (SolrServerException e) {
-			LOG.info("Purge at: " + url + " failed!");
-			e.printStackTrace();
+		server.deleteByQuery("*:*");
+		server.commit();
+
+		// Probably worked, so let's destroy the log if there is one.
+		if( globalSolrLogFile != null && globalSolrLogFile.exists() ){
+		    boolean yes_p = globalSolrLogFile.delete();
+		    if( yes_p ){
+		        LOG.info("Deleted GOlr load log file.");
+		    }else{
+		        // Nothing there, doing nothing.
+		    }
 		}
 		LOG.info("Purged: " + url);
 	}
@@ -317,83 +312,79 @@ public class SolrCommandRunner extends TaxonCommandRunner {
         boolean isMock = false;
 		int nClasses = 0;
 		// Actual ontology class loading.
-		try {
-		    FlexSolrDocumentLoader loader;
-	        if (url.equals("mock")) {
-	            loader = new MockFlexSolrDocumentLoader(flex);
-	            isMock = true;
-	        }
-	        else {
-	            loader = new FlexSolrDocumentLoader(url, flex);
-	        }
-		    
-			LOG.info("Trying ontology flex load.");
-			loader.load();
-			
-			// number of docs loaded MUST be equal to or higher than minClasses
-			// (docs also comprises non-class documents, e.g. ObjectProperties)
-			if (loader.getCurrentDocNumber() < minClasses) {
-	            LOG.error("Fewer documents loaded than expected: "+loader.getCurrentDocNumber()+" < "+minClasses);
-	            exit(1);			    
-			}
-			
-			// Load likely successful--log it.
-			//optionallyLogLoad("ontology", ???);
-			// TODO: Well, this is a lame second best.
-			//for( OWLOntology o : g.getAllOntologies() ){
-			for( OWLOntology o : g.getManager().getOntologies() ){
-					
-				//optionallyLogLoad("ontology", o.getOntologyID().toString());
-				// This is "correct", but I'm only getting one.
-				String ont_id = "unknown";
-				String ont_version = "unknown";
-				try {
-					if (o.getOntologyID() !=  null) {
-						Optional<IRI> optional = o.getOntologyID().getOntologyIRI();
-						if (optional.isPresent()) {
-							ont_id = optional.get().toString();
-						}
-						else {
-							LOG.info("Failed to get ID of: " + o.toString() + "!");
-						}
-					}
-				} catch (NullPointerException e) {
-					LOG.info("Failed to get ID of: " + o.toString() + "!");
-				}
-				
-				try {
-					Optional<IRI> versionIRI = o.getOntologyID().getVersionIRI();
-					if (versionIRI.isPresent()){
-						ont_version = versionIRI.get().toString();
-						Pattern p = Pattern.compile("(\\d{4}-\\d{2}-\\d{2})");
-						Matcher m = p.matcher(ont_version);
-						m.find();
-						ont_version = m.group(0);
-						//ont_version = StringUtils.substringBetween(ont_version, "releases/", "/");
-					}
-					else {
-						ont_version = null;
-					}
-					if( ont_version == null || ont_version.equals("") ){
-						// Sane fallback.
-						LOG.info("Failed to extract version of: " + ont_id + "!");
-					}
-				} catch (NullPointerException e) {
-					LOG.info("Failed to get version of: " + ont_id + "!");
-				} catch (IllegalStateException e) {
-					LOG.info("Failed to get match for version of: " + ont_id + "!");
-				}
-				optionallyLogLoad("ontology", ont_id, ont_version);
-				
-		        if (isMock) {
-		            showMockDocs((MockSolrDocumentLoader) loader);
-		        }
-
-			}
-		} catch (SolrServerException e) {
-			LOG.info("Ontology load at: " + url + " failed!");
-			e.printStackTrace();
+		FlexSolrDocumentLoader loader;
+		if (url.equals("mock")) {
+		    loader = new MockFlexSolrDocumentLoader(flex);
+		    isMock = true;
 		}
+		else {
+		    loader = new FlexSolrDocumentLoader(url, flex);
+		}
+
+		LOG.info("Trying ontology flex load.");
+		loader.load();
+
+		// number of docs loaded MUST be equal to or higher than minClasses
+		// (docs also comprises non-class documents, e.g. ObjectProperties)
+		if (loader.getCurrentDocNumber() < minClasses) {
+		    LOG.error("Fewer documents loaded than expected: "+loader.getCurrentDocNumber()+" < "+minClasses);
+		    exit(1);			    
+		}
+
+		// Load likely successful--log it.
+		//optionallyLogLoad("ontology", ???);
+		// TODO: Well, this is a lame second best.
+		//for( OWLOntology o : g.getAllOntologies() ){
+		for( OWLOntology o : g.getManager().getOntologies() ){
+
+		    //optionallyLogLoad("ontology", o.getOntologyID().toString());
+		    // This is "correct", but I'm only getting one.
+		    String ont_id = "unknown";
+		    String ont_version = "unknown";
+		    try {
+		        if (o.getOntologyID() !=  null) {
+		            Optional<IRI> optional = o.getOntologyID().getOntologyIRI();
+		            if (optional.isPresent()) {
+		                ont_id = optional.get().toString();
+		            }
+		            else {
+		                LOG.info("Failed to get ID of: " + o.toString() + "!");
+		            }
+		        }
+		    } catch (NullPointerException e) {
+		        LOG.info("Failed to get ID of: " + o.toString() + "!");
+		    }
+
+		    try {
+		        Optional<IRI> versionIRI = o.getOntologyID().getVersionIRI();
+		        if (versionIRI.isPresent()){
+		            ont_version = versionIRI.get().toString();
+		            Pattern p = Pattern.compile("(\\d{4}-\\d{2}-\\d{2})");
+		            Matcher m = p.matcher(ont_version);
+		            m.find();
+		            ont_version = m.group(0);
+		            //ont_version = StringUtils.substringBetween(ont_version, "releases/", "/");
+		        }
+		        else {
+		            ont_version = null;
+		        }
+		        if( ont_version == null || ont_version.equals("") ){
+		            // Sane fallback.
+		            LOG.info("Failed to extract version of: " + ont_id + "!");
+		        }
+		    } catch (NullPointerException e) {
+		        LOG.info("Failed to get version of: " + ont_id + "!");
+		    } catch (IllegalStateException e) {
+		        LOG.info("Failed to get match for version of: " + ont_id + "!");
+		    }
+		    optionallyLogLoad("ontology", ont_id, ont_version);
+
+		    if (isMock) {
+		        showMockDocs((MockSolrDocumentLoader) loader);
+		    }
+
+		}
+		
 	}
 	
 
@@ -413,14 +404,9 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		String url = sortOutSolrURL(globalSolrURL);				
 
 		// Actual ontology class loading.
-		try {
-			OntologyGeneralSolrDocumentLoader loader = new OntologyGeneralSolrDocumentLoader(url, g);
-			LOG.info("Trying ontology general load.");
-			loader.load();
-		} catch (SolrServerException e) {
-			LOG.info("Ontology load at: " + url + " failed!");
-			e.printStackTrace();
-		}
+		OntologyGeneralSolrDocumentLoader loader = new OntologyGeneralSolrDocumentLoader(url, g);
+		LOG.info("Trying ontology general load.");
+		loader.load();
 	}
 	
 	/**
@@ -523,6 +509,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		boolean removeTemplateModels = false;
         boolean removeUnsatisfiableModels = false;
         boolean exitIfUnsatisfiable = true;
+        boolean exitIfLoadFails = true;
 		while (opts.hasOpts()) {
 			if (opts.nextEq("--defaultModelStateFilter|--productionModelStateFilter")) {
 				if(modelStateFilter != null) { 
@@ -552,10 +539,14 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			else if (opts.nextEq("--excludeUnsatisfiableModels|--excludeUnsatisfiable")) {
 				removeUnsatisfiableModels = true;
 			}
-			else if (opts.nextEq("--includeUnsatisfiableModels|--includeUnsatisfiable")) {
-				removeUnsatisfiableModels = false;
-				exitIfUnsatisfiable = false;
-			}
+            else if (opts.nextEq("--includeUnsatisfiableModels|--includeUnsatisfiable")) {
+                removeUnsatisfiableModels = false;
+                exitIfUnsatisfiable = false;
+            }
+            else if (opts.nextEq("--noExitIfLoadFails")) {
+                opts.info("", "carry on if fail to load any individual model fails. Default is fail fast");
+                exitIfLoadFails = false;
+            }
 			else
 				break;
 
@@ -644,6 +635,9 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 					} catch (SolrServerException e) {
 						LOG.info("Complex annotation load of " + fname + " at " + url + " failed!");
 						e.printStackTrace();
+						if (exitIfLoadFails) {
+						    System.exit(1);
+						}
 					}
 					finally {
 						IOUtils.closeQuietly(loader);
@@ -738,6 +732,8 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 						continue;
 					}
 					Set<OWLClass> unsatisfiable = currentReasoner.getUnsatisfiableClasses().getEntitiesMinusBottom();
+					
+					// TODO - make configurable to allow fail fast
 					if (unsatisfiable.isEmpty() == false) {
 						LOG.info("Skip since unsatisfiable: " + fname);
 						continue;
@@ -754,6 +750,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 					} catch (SolrServerException e) {
 						LOG.info("Complex annotation load of " + fname + " at " + url + " failed!");
 						e.printStackTrace();
+						System.exit(1);
 					}
 				} finally {
 					// Cleanup reasoner and ontology.
@@ -830,6 +827,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 					} catch (SolrServerException e) {
 						LOG.info("Complex annotation load of " + fname + " at " + url + " failed!");
 						e.printStackTrace();
+						System.exit(1);
 					}
 				} finally {
 					// Cleanup reasoner and ontology.
@@ -1026,27 +1024,27 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 * @param opts
 	 * @throws Exception
 	 */
-	@CLIMethod("--solr-load-gpads")
-	public void loadGPADsSolr(Opts opts) throws Exception {
-		// Check to see if the global url has been set.
-		//String url = sortOutSolrURL(globalSolrURL);
-
-		List<String> files = opts.nextList();
-		if( files.size() % 2 != 0 ){
-			System.err.println("GPAD format comes in pairs; skipping...");
-		}else{
-			while( ! files.isEmpty() ){
-				String car = files.remove(0);
-				String cdr = files.remove(0);
-				LOG.info("Parsing GPAD car: " + car);
-				LOG.info("Parsing GPAD cdr: " + cdr);
-				// TODO: a new buildDocument that takes the two GPAD arguments.
-				//GafObjectsBuilder builder = new GafObjectsBuilder();
-				//gafdoc = builder.buildDocument(car, cdr);
-				//loadGAFDoc(url, gafdoc);
-			}
-		}
-	}
+//	@CLIMethod("--solr-load-gpads")
+//	public void loadGPADsSolr(Opts opts) throws Exception {
+//		// Check to see if the global url has been set.
+//		//String url = sortOutSolrURL(globalSolrURL);
+//
+//		List<String> files = opts.nextList();
+//		if( files.size() % 2 != 0 ){
+//			System.err.println("GPAD format comes in pairs; skipping...");
+//		}else{
+//			while( ! files.isEmpty() ){
+//				String car = files.remove(0);
+//				String cdr = files.remove(0);
+//				LOG.info("Parsing GPAD car: " + car);
+//				LOG.info("Parsing GPAD cdr: " + cdr);
+//				// TODO: a new buildDocument that takes the two GPAD arguments.
+//				//GafObjectsBuilder builder = new GafObjectsBuilder();
+//				//gafdoc = builder.buildDocument(car, cdr);
+//				//loadGAFDoc(url, gafdoc);
+//			}
+//		}
+//	}
 	
 	/**
 	 * Used for applying the panther trees to the currently data run.
@@ -1228,7 +1226,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	/*
 	 * Wrapper multiple places where there is direct GAF loading.
 	 */
-	private void loadGAFDoc(String url, GafDocument gafdoc, EcoTools eco, TaxonTools taxo, PANTHERForest pset, String taxonSubsetName, String ecoSubsetName) throws IOException{
+	private void loadGAFDoc(String url, GafDocument gafdoc, EcoTools eco, TaxonTools taxo, PANTHERForest pset, String taxonSubsetName, String ecoSubsetName) throws IOException, SolrServerException{
 
 		// Seth's head explodes with non-end return!
 		// TODO: Ask Chris if there is any reason to have null on empty GAFs.
@@ -1255,20 +1253,9 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		loader.setTaxonSubsetName(taxonSubsetName);
 		loader.setEcoSubsetName(ecoSubsetName);
 		loader.setGraph(g);
-		try {
-			LOG.info("Loading server at: " + url + " with: " + gafdoc.getDocumentPath());
-			loader.load();
-		} catch (java.lang.NullPointerException e) { // can trigger when the GAF is empty
-			LOG.warn("Huh...some null pointer exception...good luck! At: " + url + ", " + gafdoc.getDocumentPath());
-			//LOG.warn("Message: " + e.getMessage());
-			e.printStackTrace();
-		} catch (SolrException e) { // can trigger when there is more than one PANTHER tree
-			LOG.warn("Possible PANTHER error: " + url + " with: " + e.toString());
-			e.printStackTrace();
-		} catch (SolrServerException e) {
-			LOG.warn("Something has gone south with Solr: " + url);
-			e.printStackTrace();
-		}
+		LOG.info("Loading server at: " + url + " with: " + gafdoc.getDocumentPath());
+		loader.load();
+
         if (isMock) {
             showMockDocs((MockSolrDocumentLoader) loader);
         }


### PR DESCRIPTION
…rown

Previously these were caught and printed out on stderr. This is not so good as
they are buried in the masses of log messages meaning problems leak into production
potentially

Changed behavior so that exceptions are not caught. This will cause the current command
to die, and to exit with a non-zero error code. Fixes #223

Note that in two places we still wrap with a try{}, in the experimental model loading.
However, the behavior has been changed here to explicitly exit with non-zero if
any exceptions are caught