### PR TITLE
Add codes that check the return value of getGoSubOntology in the initialization routine of aspectMap.

### DIFF
--- a/OWLTools-Annotation/src/main/java/owltools/gaf/inference/BasicAnnotationPropagator.java
+++ b/OWLTools-Annotation/src/main/java/owltools/gaf/inference/BasicAnnotationPropagator.java
@@ -380,20 +380,32 @@ public class BasicAnnotationPropagator extends AbstractAnnotationPredictor imple
 		
 		OWLClass mf = graph.getOWLClassByIdentifier("GO:0003674"); // molecular_function
 		if (mf != null) {
-			map.put(getGoSubOntology(mf, graph), "F");
+			String mfKey = getGoSubOntology(mf, graph);
+			if (mfKey == null) 
+				throw new RuntimeException("Could not retrieve sub-ontology for GO:0003674 (molecular_function). The value of the OBO-namespace tag does not exist.");
+			
+			map.put(mfKey, "F");
 		}
 		
 		OWLClass bp = graph.getOWLClassByIdentifier("GO:0008150"); // biological_process
 		if (bp != null) {
-			map.put(getGoSubOntology(bp, graph), "P");
+			String bpKey = getGoSubOntology(bp, graph);
+			if (bpKey == null) 
+				throw new RuntimeException("Could not retrieve sub-ontology for GO:0008150 (biological_process). The value of the OBO-namespace tag does not exist.");
+
+			map.put(bpKey, "P");
 		}
 		
 		OWLClass cc = graph.getOWLClassByIdentifier("GO:0005575"); // cellular_component
 		if (cc != null) {
-			map.put(getGoSubOntology(cc, graph), "C");
+			String ccKey = getGoSubOntology(cc, graph);
+			if (ccKey == null) 
+				throw new RuntimeException("Could not retrieve sub-ontology for GO:0005575 (celluar_component). The value of the OBO-namespace tag does not exist.");
+
+			map.put(ccKey, "C");
 		}
 		
-		if (map.isEmpty()) {
+		if (map.isEmpty() || map.containsKey(null)) {
 			// only fail if there are mappings
 			// the test case uses a custom ontology, which has no cc branch
 			throw new RuntimeException("Could not create any valid aspect mappings. Is the correct ontology (GO) loaded?");


### PR DESCRIPTION
This patch is built for covering this [issue](https://github.com/owlcollab/owltools/issues/237), i.e. the current Owltools produces incorrect aspects in predicted GAFs when the values of relevant obo-namespace tags do not exist. To solve this issue, I added codes that check the return value of `getGoSubOntology` before using that value as key, so that the generation of `aspectMap` with null keys can be avoided. 