### PR TITLE
Added codes for generating regulation-only closures

### DIFF
--- a/OWLTools-Core/src/main/java/owltools/graph/RelationSets.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/RelationSets.java
@@ -7,7 +7,7 @@ public class RelationSets {
 
     public static final String ISA_PARTOF = "is_a/part_of";
     public static final String REGULATES = "regulates/is_a/part_of";
-
+    public static final String REGULATES_ONLY = "regulates/part_of";
     /*
      * Should be using this in most cases.
      */
@@ -24,6 +24,10 @@ public class RelationSets {
 				rel_ids.add("BFO:0000050");
 			}else if( relset.equals(REGULATES) ){
 				rel_ids.add("BFO:0000050");
+				rel_ids.add("RO:0002211");
+				rel_ids.add("RO:0002212");
+				rel_ids.add("RO:0002213");
+			}else if( relset.equals(REGULATES_ONLY) ){
 				rel_ids.add("RO:0002211");
 				rel_ids.add("RO:0002212");
 				rel_ids.add("RO:0002213");

--- a/OWLTools-Solr/src/main/java/owltools/solrj/GafSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/GafSolrDocumentLoader.java
@@ -327,6 +327,8 @@ public class GafSolrDocumentLoader extends AbstractSolrLoader {
 		// added at the end of this section.
 		Map<String, String> isap_map = new HashMap<String, String>();
 		Map<String, String> reg_map = new HashMap<String, String>();
+		Map<String, String> reg_only_map = new HashMap<String, String>();
+
 		for (GeneAnnotation a : gafDocument.getGeneAnnotations(e.getId())) {
 			SolrInputDocument annotation_doc = new SolrInputDocument();
 
@@ -438,6 +440,12 @@ public class GafSolrDocumentLoader extends AbstractSolrLoader {
 				Map<String, String> curr_reg_map = addClosureToAnnAndBio(reg, "regulates_closure", "regulates_closure_label", "regulates_closure_map",
 						  			               cls, graph, annotation_doc, bioentity_doc, a.isNegated());
 				reg_map.putAll(curr_reg_map); // add to aggregate map
+
+				// Regulates ONLY closures.
+				List<String> reg_only = RelationSets.getRelationSet(RelationSets.REGULATES_ONLY);
+				Map<String, String> curr_reg_only_map = addClosureToAnnAndBio(reg_only, "regulates_only_closure", "regulates_only_closure_label", "regulates_only_closure_map",
+						  			               cls, graph, annotation_doc, bioentity_doc, a.isNegated());
+				reg_only_map.putAll(curr_reg_only_map); // add to aggregate map
 			}
 
 			// Let's piggyback on a little of the work above and cache the extra stuff that we'll be adding to the bioenity at the end
@@ -544,7 +552,11 @@ public class GafSolrDocumentLoader extends AbstractSolrLoader {
 			String jsonized_cmap = gson.toJson(reg_map);
 			bioentity_doc.addField("regulates_closure_map", jsonized_cmap);
 		}
-
+		if( ! reg_only_map.isEmpty() ){
+			String jsonized_cmap = gson.toJson(reg_only_map);
+			bioentity_doc.addField("regulates_only_closure_map", jsonized_cmap);
+		}
+		
 		// Add c5 to bioentity.
 		// Compile closure map to JSON and add to the document.
 		String jsonized_direct_map = null;

--- a/OWLTools-Solr/src/test/java/owltools/solrj/GafSolrDocumentLoaderTest.java
+++ b/OWLTools-Solr/src/test/java/owltools/solrj/GafSolrDocumentLoaderTest.java
@@ -25,6 +25,7 @@ import owltools.io.ParserWrapper;
 public class GafSolrDocumentLoaderTest {
 
 	private static int solrCount = 0;
+	private static int solrCountWithRegulatesOnly = 0;
 	private static OWLGraphWrapper graph;
 	private static TaxonTools taxonTools = null;
 	private static GafSolrDocumentLoader loader;
@@ -36,9 +37,12 @@ public class GafSolrDocumentLoaderTest {
 			@Override
 			protected void addToServer(Collection<SolrInputDocument> docs)
 					throws SolrServerException, IOException {
+				for (SolrInputDocument doc: docs) {
+					if (doc.toString().contains("regulates_only_closure"))
+						solrCountWithRegulatesOnly +=1 ;
+				}
 				solrCount += docs.size();
 			}
-			
 		};
 		ParserWrapper pw = new ParserWrapper();
 		pw.addIRIMapper(new CatalogXmlIRIMapper("../OWLTools-Annotation/src/test/resources/rules/ontology/extensions/catalog-v001.xml"));
@@ -83,6 +87,6 @@ public class GafSolrDocumentLoaderTest {
 		loader.load();
 
 		assertTrue(solrCount > 0);
+		assertTrue(solrCountWithRegulatesOnly > 0);
 	}
-
 }


### PR DESCRIPTION
I added additional codes for generating regulation-only/strict closures in owltools, as requested in [this issue](https://github.com/owlcollab/owltools/issues/241). I also slightly extended the testcase to confirm that closures are generated in the resulting `SolrInputDocument` objects, but please let me know if any other features or codes are necessary. Thank you.
