### PR TITLE
Fixed memory leaks that arise while generating solr index entries

### DIFF
--- a/OWLTools-Core/pom.xml
+++ b/OWLTools-Core/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -30,8 +31,8 @@
 				<configuration>
 					<excludes>
 						<!-- May exclude because they use GO; they take a while to run. -->
-<!-- 						<exclude>owltools/graph/OWLGraphShuntTest.java</exclude> --><!-- I ran into a funny case where I needed to know this... -->
-						<exclude>owltools/graph/OWLGraphManipulatorTest.java</exclude> 	
+						<!-- <exclude>owltools/graph/OWLGraphShuntTest.java</exclude> --><!-- I ran into a funny case where I needed to know this... -->
+						<exclude>owltools/graph/OWLGraphManipulatorTest.java</exclude>
 						<exclude>owltools/graph/DLLikeQueryTest.java</exclude>
 						<exclude>owltools/graph/AncestorsTest.java</exclude>
 						<exclude>owltools/gfx/DrawOmmatidiumTest.java</exclude>
@@ -107,12 +108,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.geneontology</groupId>
- 			<artifactId>expression-materializing-reasoner</artifactId>
+			<artifactId>expression-materializing-reasoner</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.geneontology</groupId>
- 			<artifactId>obographs</artifactId>
- 			<version>0.1.0</version>
+			<artifactId>obographs</artifactId>
+			<version>0.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperBasic.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperBasic.java
@@ -15,7 +15,6 @@ import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAnnotationSubject;
-import org.semanticweb.owlapi.model.OWLAnnotationValue;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDataFactory;
@@ -40,7 +39,7 @@ import owltools.io.ParserWrapper;
  * @see OWLGraphWrapper
  */
 public class OWLGraphWrapperBasic {
-	
+
 	private static final Logger LOG = Logger.getLogger(OWLGraphWrapperBasic.class);
 
 	protected OWLOntology sourceOntology; // graph is seeded from this ontology.
@@ -51,7 +50,7 @@ public class OWLGraphWrapperBasic {
 		super();
 		sourceOntology = ontology;
 	}
-	
+
 	protected OWLGraphWrapperBasic(String iri) throws OWLOntologyCreationException {
 		super();
 		ParserWrapper pw = new ParserWrapper();
@@ -86,9 +85,9 @@ public class OWLGraphWrapperBasic {
 	}
 
 	public enum LabelPolicy {
-	    ALLOW_DUPLICATES,
-	    PRESERVE_SOURCE,
-	    PRESERVE_EXT
+		ALLOW_DUPLICATES,
+		PRESERVE_SOURCE,
+		PRESERVE_EXT
 	}
 	/**
 	 * Adds all axioms from extOnt into source ontology
@@ -96,39 +95,39 @@ public class OWLGraphWrapperBasic {
 	 * @param extOnt
 	 * @throws OWLOntologyCreationException
 	 */
-    public void mergeOntology(OWLOntology extOnt) throws OWLOntologyCreationException {
-        mergeOntology(extOnt, LabelPolicy.ALLOW_DUPLICATES);
-    }
+	public void mergeOntology(OWLOntology extOnt) throws OWLOntologyCreationException {
+		mergeOntology(extOnt, LabelPolicy.ALLOW_DUPLICATES);
+	}
 	public void mergeOntology(OWLOntology extOnt, LabelPolicy labelPolicy) throws OWLOntologyCreationException {
 		OWLOntologyManager manager = getManager();
 		LOG.info("Merging "+extOnt+" policy: "+labelPolicy);
 		for (OWLAxiom axiom : extOnt.getAxioms()) {
-		    if (labelPolicy != LabelPolicy.ALLOW_DUPLICATES) {
-		        if (axiom instanceof OWLAnnotationAssertionAxiom) {
-		            OWLAnnotationAssertionAxiom aa = (OWLAnnotationAssertionAxiom)axiom;
-		            if (aa.getProperty().isLabel()) {
-		                OWLAnnotationSubject subj = aa.getSubject();
-		                if (subj instanceof IRI) {
-		                    Optional<OWLLiteral> label = null;
-		                    for (OWLAnnotationAssertionAxiom a1 : sourceOntology.getAnnotationAssertionAxioms(subj)) {
-		                        if (a1.getProperty().isLabel()) {
-		                            label = a1.getValue().asLiteral();
-		                        }
-		                    }
-		                    if (label != null && label.isPresent()) {
-                                if (labelPolicy == LabelPolicy.PRESERVE_SOURCE) {
-                                    LOG.info("Preserving existing label:" +subj+" "+label+" // ditching: "+axiom);
-                                    continue;
-                                }
-                                if (labelPolicy == LabelPolicy.PRESERVE_EXT) {
-                                    LOG.info("Replacing:" +subj+" "+label+" with: "+axiom);
-                                    LOG.error("NOT IMPLEMENTED");
-                                }
-		                    }
-		                }
-		            }
-		        }
-		    }
+			if (labelPolicy != LabelPolicy.ALLOW_DUPLICATES) {
+				if (axiom instanceof OWLAnnotationAssertionAxiom) {
+					OWLAnnotationAssertionAxiom aa = (OWLAnnotationAssertionAxiom)axiom;
+					if (aa.getProperty().isLabel()) {
+						OWLAnnotationSubject subj = aa.getSubject();
+						if (subj instanceof IRI) {
+							Optional<OWLLiteral> label = null;
+							for (OWLAnnotationAssertionAxiom a1 : sourceOntology.getAnnotationAssertionAxioms(subj)) {
+								if (a1.getProperty().isLabel()) {
+									label = a1.getValue().asLiteral();
+								}
+							}
+							if (label != null && label.isPresent()) {
+								if (labelPolicy == LabelPolicy.PRESERVE_SOURCE) {
+									LOG.info("Preserving existing label:" +subj+" "+label+" // ditching: "+axiom);
+									continue;
+								}
+								if (labelPolicy == LabelPolicy.PRESERVE_EXT) {
+									LOG.info("Replacing:" +subj+" "+label+" with: "+axiom);
+									LOG.error("NOT IMPLEMENTED");
+								}
+							}
+						}
+					}
+				}
+			}
 			manager.applyChange(new AddAxiom(sourceOntology, axiom));
 		}
 		for (OWLImportsDeclaration oid: extOnt.getImportsDeclarations()) {
@@ -144,18 +143,18 @@ public class OWLGraphWrapperBasic {
 			this.supportOntologySet.remove(extOnt);
 		}
 	}
-	
+
 	static CharSequence summarizeOntology(OWLOntology ontology) {
-	    StringBuilder sb = new StringBuilder();
-	    sb.append("Ontology(");
-	    sb.append(ontology.getOntologyID());
-	    sb.append(") [Axioms: ");
-	    int axiomCount = ontology.getAxiomCount();
-	    sb.append(axiomCount);
-	    sb.append(" Logical Axioms: ");
-	    sb.append(ontology.getLogicalAxiomCount());
-	    sb.append("]");
-	    return sb;
+		StringBuilder sb = new StringBuilder();
+		sb.append("Ontology(");
+		sb.append(ontology.getOntologyID());
+		sb.append(") [Axioms: ");
+		int axiomCount = ontology.getAxiomCount();
+		sb.append(axiomCount);
+		sb.append(" Logical Axioms: ");
+		sb.append(ontology.getLogicalAxiomCount());
+		sb.append("]");
+		return sb;
 	}
 
 
@@ -172,7 +171,7 @@ public class OWLGraphWrapperBasic {
 			mergeSupportOntology(IRI.create(ontologyIRI), isRemoveFromSupportList);
 		}
 	}
-	
+
 	public void mergeSupportOntology(IRI ontologyIRI, boolean isRemoveFromSupportList) throws OWLOntologyCreationException {
 		OWLOntology extOnt = null;
 		for (OWLOntology ont : this.supportOntologySet) {
@@ -199,7 +198,7 @@ public class OWLGraphWrapperBasic {
 	public void mergeSupportOntology(String ontologyIRI) throws OWLOntologyCreationException {
 		mergeSupportOntology(ontologyIRI, true);
 	}
-	
+
 	public void mergeSupportOntology(IRI ontologyIRI) throws OWLOntologyCreationException {
 		mergeSupportOntology(ontologyIRI, true);
 	}
@@ -259,7 +258,7 @@ public class OWLGraphWrapperBasic {
 	public void addSupportOntologiesFromImportsClosure(boolean doForAllSupportOntologies) {
 		Set<OWLOntology> ios = new HashSet<OWLOntology>();
 		ios.add(sourceOntology);
-		
+
 		if (doForAllSupportOntologies) {
 			ios.addAll(getSupportOntologySet());
 		}
@@ -271,7 +270,7 @@ public class OWLGraphWrapperBasic {
 			}
 		}
 	}
-	
+
 	public void addImportsFromSupportOntologies() {
 		OWLOntology sourceOntology = getSourceOntology();
 		OWLDataFactory factory = getDataFactory();
@@ -315,11 +314,11 @@ public class OWLGraphWrapperBasic {
 		for (OWLOntology o : imports) {
 			if (o.equals(sourceOntology))
 				continue;
-			
+
 			String comment = "Includes "+summarizeOntology(o);
 			LOG.info(comment);
 			addCommentToOntology(sourceOntology, comment);
-			
+
 			manager.addAxioms(sourceOntology, o.getAxioms());
 		}
 		Set<OWLImportsDeclaration> oids = sourceOntology.getImportsDeclarations();
@@ -328,7 +327,7 @@ public class OWLGraphWrapperBasic {
 			getManager().applyChange(ri);
 		}
 	}
-	
+
 	/**
 	 * Merge a specific ontology from the import closure into the main ontology.
 	 * Removes the import statement.
@@ -396,8 +395,8 @@ public class OWLGraphWrapperBasic {
 			obs.addAll(o.getIndividualsInSignature());
 			obs.addAll(o.getObjectPropertiesInSignature());
 		}
-        obs.remove(getDataFactory().getOWLThing());
-        obs.remove(getDataFactory().getOWLNothing());
+		obs.remove(getDataFactory().getOWLThing());
+		obs.remove(getDataFactory().getOWLNothing());
 		return obs;
 	}
 
@@ -414,7 +413,7 @@ public class OWLGraphWrapperBasic {
 		}
 		return owlClasses;
 	}
-	
+
 	/**
 	 * Fetch all {@link OWLSubClassOfAxiom} axioms for a given subClass
 	 * ({@link OWLClass}) from all ontologies. This set is a copy. Changes are
@@ -430,7 +429,7 @@ public class OWLGraphWrapperBasic {
 		}
 		return axioms;
 	}
-	
+
 	/**
 	 * Fetch all {@link OWLSubClassOfAxiom} axioms for a given superClass
 	 * ({@link OWLClass}) from all ontologies. This set is a copy. Changes are

--- a/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperEdgesAdvanced.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperEdgesAdvanced.java
@@ -2,20 +2,16 @@ package owltools.graph;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.SerializationUtils;
 import org.apache.log4j.Logger;
 import org.geneontology.reasoner.ExpressionMaterializingReasoner;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
@@ -39,18 +35,13 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLPropertyExpression;
 import org.semanticweb.owlapi.model.OWLPropertyExpressionVisitor;
 import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
-import org.semanticweb.owlapi.reasoner.NodeSet;
-import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.util.OWLClassExpressionVisitorAdapter;
 
 import owltools.graph.shunt.OWLShuntEdge;
 import owltools.graph.shunt.OWLShuntGraph;
 import owltools.graph.shunt.OWLShuntNode;
 import owltools.util.OwlHelper;
-import uk.ac.manchester.cs.owl.owlapi.OWLClassImpl;
-import uk.ac.manchester.cs.owl.owlapi.OWLObjectSomeValuesFromImpl;
 
-import com.beust.jcommander.internal.Sets;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -60,14 +51,9 @@ import com.google.common.cache.LoadingCache;
  * @see OWLGraphWrapperEdges
  */
 public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended implements Closeable {
+
 	private static Logger LOG = Logger.getLogger(OWLGraphWrapper.class);
-	private volatile ExpressionMaterializingReasoner reasoner = null;
-	private volatile boolean isSynchronized = false;	
-	private final Set<OWLObjectProperty> materializationPropertySet = new HashSet<OWLObjectProperty>();
-	// A cache of an arbitrary relationship closure for a certain object.
-	private LoadingCache<OWLObject, Map<List<String>,Map<String,String>>> cache = null;
-	private int cacheSize = 100000; // default size
-	
+
 	protected OWLGraphWrapperEdgesAdvanced(OWLOntology ontology) {
 		super(ontology);
 	}
@@ -75,6 +61,13 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 	protected OWLGraphWrapperEdgesAdvanced(String iri) throws OWLOntologyCreationException {
 		super(iri);
 	}
+	
+	private volatile ExpressionMaterializingReasoner reasoner = null;
+	private volatile boolean isSynchronized = false;
+
+	// A cache of an arbitrary relationship closure for a certain object.
+	private LoadingCache<OWLObject, Map<List<String>,Map<String,String>>> cache = null;
+	private int cacheSize = 100000; // default size
 	
 	public void setEdgesAdvancedCacheSize(int size) {
 		this.cacheSize = size;
@@ -86,6 +79,8 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 		}
 		return 0;
 	}
+	
+	private final Set<OWLObjectProperty> materializationPropertySet = new HashSet<OWLObjectProperty>();
 	
 	public synchronized void addPropertyForMaterialization(OWLObjectProperty p) {
 		boolean add = materializationPropertySet.add(p);
@@ -129,9 +124,7 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 			reasoner = null;
 			isSynchronized = false;
 		}
-
-		cache.invalidateAll();
-		cache.cleanUp();
+		neighborAxioms = null;
 	}
 
 	/**
@@ -152,6 +145,7 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 		return props;
 	}
 
+	
 	/**
 	 * Classify the an edge and target as a human readable string for further processing.
 	 * 
@@ -190,6 +184,7 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 		return retval;
 	}
 
+	
 	/**
 	 * Add a set of edges, as ancestors to x in OWLShuntGraph g.
 	 * This is reflexive.
@@ -666,6 +661,7 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 	 * @see #getRelationClosureMap(OWLObject, List)
 	 */
 	public Map<String,String> getRelationClosureMapEngine(OWLObject obj, List<String> relation_ids){
+
 		final Map<String,String> relation_map = new HashMap<String,String>(); // capture labels/ids
 		
 		// reflexive
@@ -675,56 +671,26 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 		
 		// Our relation collection.
 		final Set<OWLObjectProperty> props = relationshipIDsToPropertySet(relation_ids);
-		if (obj instanceof OWLClass)
-			addIdLabelClosure((OWLClass) obj, true, props, relation_map);
-		else if (obj instanceof OWLObjectProperty)
-			addIdLabelClosure((OWLObjectProperty) obj, true, relation_map);
 		
+		if (obj instanceof OWLClass) {
+			addIdLabelClosure((OWLClass) obj, true, props, relation_map);
+		}
+		else if (obj instanceof OWLObjectProperty) {
+			addIdLabelClosure((OWLObjectProperty) obj, true, relation_map);
+		}
 		return relation_map;
 	}
 	
 	private void addIdLabelClosure(OWLClass c, boolean reflexive, 
 			final Set<OWLObjectProperty> props, final Map<String,String> relation_map) {
+		addPropertiesForMaterialization(props);
+		ExpressionMaterializingReasoner materializingReasoner = getMaterializingReasoner();
+		Set<OWLClassExpression> classExpressions = materializingReasoner.getSuperClassExpressions(c, false);
+		OWLEntity owlThing = this.getManager().getOWLDataFactory().getOWLThing();
 		
-		Set<OWLClassExpression> classExpressions = Sets.newHashSet();
-		try {
-			addPropertiesForMaterialization((Iterable<OWLObjectProperty>) SerializationUtils.clone((Serializable) props));
-			getMaterializingReasoner();
-
-			// The following block of codes are built based on the ones in ExpressionMaterializingReasoner's 
-			// getSuperClassExpressions. The original codes use that method to get all super class expressions for a given class c,  
-			// but those codes had memory leaks while those codes are in the separate external library (ExpressionMateiralizingReasoner's jar), 
-			// thus it was difficult to fix those codes. As a temporary measure, I copied and extended the codes here.
-			Field cxMapField = ExpressionMaterializingReasoner.class.getDeclaredField("cxMap");
-			cxMapField.setAccessible(true);
-			Map<OWLClass,OWLObjectSomeValuesFrom> cxMap = (Map<OWLClass, OWLObjectSomeValuesFrom>) cxMapField.get(reasoner);
-			OWLReasoner wrappedReasoner = (OWLReasoner) SerializationUtils.clone((Serializable) reasoner.getWrappedReasoner());
-			OWLClassExpression cClone = (OWLClassExpression) SerializationUtils.clone(c);
-			Set<OWLClass> ocSet = wrappedReasoner.getSuperClasses(cClone, false).getFlattened();
-			Iterator<OWLClass> ocSetIter = ocSet.iterator();
-			while (ocSetIter.hasNext()) {
-				OWLClass ocClone = (OWLClass) SerializationUtils.clone(ocSetIter.next());
-				if (cxMap.containsKey(ocClone)) {
-					OWLObjectSomeValuesFrom osvfClone = (OWLObjectSomeValuesFrom) SerializationUtils.clone(cxMap.get(ocClone));
-					classExpressions.add(osvfClone);
-				} else {
-					classExpressions.add(ocClone);
-				}
-			}
-
-			ocSet.clear();
-			wrappedReasoner.flush();
-			wrappedReasoner.dispose();
-			wrappedReasoner = null;
-		} catch (Exception e) {
-			LOG.error(e.getMessage());
-		}
-
 		// remove owl:Thing - although logically valid, it is not of use to the consumer
 		// see https://github.com/geneontology/amigo/issues/395
-		OWLClass owlThing = this.getManager().getOWLDataFactory().getOWLThing();
 		classExpressions = classExpressions.stream().filter(x -> !x.getSignature().contains(owlThing)).collect(Collectors.toSet());
-
 		for (OWLClassExpression ce : classExpressions) {
 			ce.accept(new OWLClassExpressionVisitorAdapter(){
 
@@ -748,13 +714,12 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 							relation_map.put(id, label);
 						}
 					}
-				}				
+				}
+				
 			});
 		}
-		
-		classExpressions.clear();
 	}
-
+	
 	private void addIdLabelClosure(OWLObjectProperty p, boolean reflexive,
 			final Map<String,String> relation_map) {
 		// using the graph walker instead of a reasoner: ELK does not implement getSuperProperties()
@@ -788,7 +753,6 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 				}
 			});
 		}
-		closure.clear();
 	}
 	
 	/**
@@ -1386,4 +1350,3 @@ public class OWLGraphWrapperEdgesAdvanced extends OWLGraphWrapperEdgesExtended i
 		}
 	}
 }
-

--- a/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperExtended.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperExtended.java
@@ -11,6 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.obolibrary.obo2owl.Obo2OWLConstants.Obo2OWLVocabulary;
+import org.apache.commons.lang.SerializationUtils;
 import org.geneontology.obographs.io.OgJsonGenerator;
 import org.geneontology.obographs.model.GraphDocument;
 import org.geneontology.obographs.owlapi.FromOwl;
@@ -117,7 +118,8 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 				label = c.toString();
 			}
 		}
-		return label;
+		
+		return (String) SerializationUtils.clone(label);
 	}
 
 	/**
@@ -179,7 +181,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 
 		return getAnnotationValues(c, lap);
 	}
-	
+
 	/**
 	 * gets all values of rdfs:comment for an OWLObject
 	 * <p>
@@ -195,8 +197,8 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 
 		return getAnnotationValues(c, lap);
 	}
-	
-	
+
+
 	/**
 	 * fetches the value of a single-valued annotation property for an OWLObject
 	 * <p>
@@ -219,9 +221,10 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		for (OWLAnnotation a : anns) {
 			if (a.getValue() instanceof OWLLiteral) {
 				OWLLiteral val = (OWLLiteral) a.getValue();
-				return val.getLiteral(); // return first - TODO - check zero or one
+				return (String) SerializationUtils.clone(val.getLiteral()); // return first - TODO - check zero or one
 			}
 		}
+
 		return null;
 	}
 
@@ -247,7 +250,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		for (OWLAnnotation a : anns) {
 			if (a.getValue() instanceof OWLLiteral) {
 				OWLLiteral val = (OWLLiteral) a.getValue();
-				list.add( val.getLiteral()); 
+				list.add( (String) SerializationUtils.clone(val.getLiteral()) ); 
 			}
 			else if (a.getValue() instanceof IRI) {
 				IRI val = (IRI)a.getValue();
@@ -552,7 +555,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		}
 		return altIdMap;
 	}
-	
+
 	/**
 	 * @param altId
 	 * @return OWLObject that has matching altId, or null if not found
@@ -837,17 +840,19 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 
 	/**
 	 * gets the OBO-style ID of the specified object. E.g. "GO:0008150"
-	 * 
+	 * ID is then cloned to avoid memory leaks.
 	 * @param owlObject
 	 * @return OBO-style identifier, using obo2owl mapping
 	 */
 	public String getIdentifier(OWLObject owlObject) {
-		return Owl2Obo.getIdentifierFromObject(owlObject, this.sourceOntology, null);
+		String identifier = Owl2Obo.getIdentifierFromObject(owlObject, this.sourceOntology, null);
+		return (String) SerializationUtils.clone(identifier);
 	}
 
 	/**
 	 * Gets the OBO-style ID of the specified object. E.g. "GO:0008150". Set the
 	 * parameter useShorthand to false to ignore shorthands.
+	 * ID is then cloned to avoid memory leaks.
 	 * 
 	 * @param owlObject
 	 * @param useShorthand
@@ -858,7 +863,8 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 			return getIdentifier(owlObject);
 		}
 		if (owlObject instanceof OWLNamedObject) {
-			return Owl2Obo.getIdentifier(((OWLNamedObject) owlObject).getIRI());
+			String identifier = Owl2Obo.getIdentifier(((OWLNamedObject) owlObject).getIRI());
+			return (String) SerializationUtils.clone(identifier);
 		}
 		return null;
 	}
@@ -878,7 +884,6 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		return getIdentifier(owlObject);
 	}
 
-
 	/**
 	 * gets the OBO-style ID of the specified object. E.g. "GO:0008150"
 	 * 
@@ -886,11 +891,13 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 	 * @return OBO-style identifier, using obo2owl mapping
 	 */
 	public String getIdentifier(IRI iriId) {
-		return Owl2Obo.getIdentifier(iriId);
+		return (String) SerializationUtils.clone(Owl2Obo.getIdentifier(iriId));
 	}
+
 	public IRI getIRIByIdentifier(String id) {
 		return getIRIByIdentifier(id, false);
 	}
+
 	public IRI getIRIByIdentifier(String id, boolean isAutoResolve) {
 		if (isAutoResolve) {
 			OWLObject obj = this.getObjectByAltId(id);
@@ -898,7 +905,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 				return ((OWLNamedObject) obj).getIRI();
 			}
 		}
-		
+
 		// special magic for finding IRIs from a non-standard identifier
 		// This is the case for relations (OWLObject properties) with a short hand
 		// or for relations with a non identifiers with-out a colon, e.g. negative_regulation
@@ -931,7 +938,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 				}
 			}
 		}
-		
+
 		// In the case where we find multiple candidate IRIs, we give priorities for IRIs from BFO or RO ontologies.
 		IRI returnIRI = null;
 		for (IRI iri: candIRISet) {
@@ -940,7 +947,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 				returnIRI = iri;
 			}
 		}
-		
+
 		// If we were not able to find RO/BFO candidate IRIs for id
 		if (returnIRI == null) {
 			// We return it only if we have only one candidate. 
@@ -954,7 +961,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		else {
 			return returnIRI;
 		}
-		
+
 		// otherwise use the obo2owl method
 		Obo2Owl b = new Obo2Owl(getManager()); // re-use manager, creating a new one can be expensive as this is a highly used code path
 		b.setObodoc(new OBODoc());
@@ -1009,8 +1016,8 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 	public OWLClass getOWLClassByIdentifier(String id) {
 		return getOWLClassByIdentifier(id, false);
 	}
-	
-	
+
+
 	/**
 	 * Given an OBO-style ID, return the corresponding OWLClass, if it is declared and not an alt_id - otherwise null
 	 * 
@@ -1024,7 +1031,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		}
 		return cls;
 	}
-	
+
 	public boolean isOboAltId(OWLEntity e) {
 		Set<OWLAnnotationAssertionAxiom> axioms = new HashSet<>();
 		for(OWLOntology ont : getAllOntologies()) {
@@ -1032,7 +1039,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		}
 		return isOboAltId(axioms);
 	}
-	
+
 	static boolean isOboAltId(Set<OWLAnnotationAssertionAxiom> annotations) {
 		boolean hasReplacedBy = false;
 		boolean isMerged = false;
@@ -1057,7 +1064,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		boolean result = hasReplacedBy && isMerged && isDeprecated;
 		return result;
 	}
-	
+
 	/**
 	 * 
 	 * As {@link #getOWLClassByIdentifier(String)} but include pre-resolution step
@@ -1469,9 +1476,9 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		}
 		return null;
 	}
-	
+
 	static final Pattern ID_SPACE_PATTERN = Pattern.compile("([a-z]+):\\d+", Pattern.CASE_INSENSITIVE);
-	
+
 	/**
 	 * Try to extract an id space from an {@link OWLObject}.
 	 * Currently it is only defined for an {@link OWLClass}, 
@@ -1493,11 +1500,11 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 				}
 				return null;
 			}
-			
+
 		});
 		return idSpace;
 	}
-	
+
 	/**
 	 * It returns the id space.
 	 * <p>
@@ -1512,7 +1519,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 	public String getIdSpace(OWLObject obj, List<String> sargs) {
 		return getIdSpace(obj);
 	}
-	
+
 	/**
 	 * Generate a OboGraphs JSON ontology blob for the local axioms for an object.
 	 * 
@@ -1529,33 +1536,33 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 	 * @throws OWLOntologyCreationException
 	 */
 	public String getOboGraphJSONString(OWLObject obj) throws JsonProcessingException, OWLOntologyCreationException {
-        FromOwl fromOwl = new FromOwl();
-        OWLOntologyManager m = sourceOntology.getOWLOntologyManager();
-        if (obj instanceof OWLNamedObject) {
-            OWLNamedObject nobj = (OWLNamedObject)obj;
-            OWLOntology ont = m.createOntology(nobj.getIRI());
-            Set<OWLAxiom> axioms = new HashSet<>();
-            if (nobj instanceof OWLClass) {
-                axioms.addAll(sourceOntology.getAxioms((OWLClass)nobj, Imports.INCLUDED));
-            }
-            else if (nobj instanceof OWLObjectProperty) {
-                axioms.addAll(sourceOntology.getAxioms((OWLObjectProperty)nobj, Imports.INCLUDED));
-            }
-            m.addAxioms(ont, axioms);
-            axioms = new HashSet<>();
-            for (OWLEntity e : ont.getSignature()) {
-                axioms.addAll(sourceOntology.getAnnotationAssertionAxioms(e.getIRI()));
-            }
-            axioms.addAll(sourceOntology.getAnnotationAssertionAxioms(nobj.getIRI()));
-            m.addAxioms(ont, axioms);
-            
-            GraphDocument gd = fromOwl.generateGraphDocument(ont);
-            return OgJsonGenerator.render(gd);
-        }
-        else {
-            return "{}";
-        }
-        
+		FromOwl fromOwl = new FromOwl();
+		OWLOntologyManager m = sourceOntology.getOWLOntologyManager();
+		if (obj instanceof OWLNamedObject) {
+			OWLNamedObject nobj = (OWLNamedObject)obj;
+			OWLOntology ont = m.createOntology(nobj.getIRI());
+			Set<OWLAxiom> axioms = new HashSet<>();
+			if (nobj instanceof OWLClass) {
+				axioms.addAll(sourceOntology.getAxioms((OWLClass)nobj, Imports.INCLUDED));
+			}
+			else if (nobj instanceof OWLObjectProperty) {
+				axioms.addAll(sourceOntology.getAxioms((OWLObjectProperty)nobj, Imports.INCLUDED));
+			}
+			m.addAxioms(ont, axioms);
+			axioms = new HashSet<>();
+			for (OWLEntity e : ont.getSignature()) {
+				axioms.addAll(sourceOntology.getAnnotationAssertionAxioms(e.getIRI()));
+			}
+			axioms.addAll(sourceOntology.getAnnotationAssertionAxioms(nobj.getIRI()));
+			m.addAxioms(ont, axioms);
+
+			GraphDocument gd = fromOwl.generateGraphDocument(ont);
+			return OgJsonGenerator.render(gd);
+		}
+		else {
+			return "{}";
+		}
+
 	}
 }
 

--- a/OWLTools-Core/src/main/java/owltools/util/HeapInfo.java
+++ b/OWLTools-Core/src/main/java/owltools/util/HeapInfo.java
@@ -1,0 +1,23 @@
+package owltools.util;
+
+import org.apache.log4j.Logger;
+
+public class HeapInfo {
+	private static final Logger LOG = Logger.getLogger(HeapInfo.class);
+
+	public static void showHeapStatus() {
+		long heapSize = Runtime.getRuntime().totalMemory(); 
+		long heapMaxSize = Runtime.getRuntime().maxMemory();
+		long heapFreeSize = Runtime.getRuntime().freeMemory(); 
+
+		LOG.info("heap size: " +  formatSize(heapSize));
+		LOG.info("heap max size: "+ formatSize(heapMaxSize));
+		LOG.info("heap free size: "+ formatSize(heapFreeSize));	
+	}
+
+	private static String formatSize(long v) {
+		if (v < 1024) return v + " B";
+		int z = (63 - Long.numberOfLeadingZeros(v)) / 10;
+		return String.format("%.1f %sB", (double)v / (1L << (z*10)), " KMGTPE".charAt(z));
+	}
+}

--- a/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
+++ b/OWLTools-Runner/src/main/java/owltools/cli/SolrCommandRunner.java
@@ -71,6 +71,7 @@ import owltools.solrj.OptimizeSolrDocumentLoader;
 import owltools.solrj.PANTHERGeneralSolrDocumentLoader;
 import owltools.solrj.PANTHERSolrDocumentLoader;
 import owltools.solrj.loader.MockSolrDocumentLoader;
+import owltools.util.HeapInfo;
 import owltools.solrj.loader.MockFlexSolrDocumentLoader;
 import owltools.solrj.loader.MockGafSolrDocumentLoader;
 import owltools.solrj.loader.MockModelAnnotationSolrDocumentLoader;
@@ -85,7 +86,7 @@ import owltools.yaml.golrconfig.SolrSchemaXMLWriter;
 public class SolrCommandRunner extends TaxonCommandRunner {
 
 	private static final Logger LOG = Logger.getLogger(SolrCommandRunner.class);
-	
+
 	private String globalSolrURL = null;
 	private File globalSolrLogFile = null;
 	private ConfigManager aconf = null;
@@ -104,7 +105,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 */
 	@CLIMethod("--solr-config")
 	public void configRead(Opts opts) {
-		
+
 		LOG.info("Grab configuration files.");
 
 		// Try and munge all of the configs together.
@@ -113,7 +114,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		for( String fsPath : confList ){
 
 			LOG.info("Trying config found at: " + fsPath);
-		
+
 			// Attempt to parse the given config file.
 			try {
 				aconf.add(fsPath);
@@ -132,7 +133,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 */
 	@CLIMethod("--solr-schema-dump")
 	public void solrSchemaDump(Opts opts) {
-		
+
 		LOG.info("Dump Solr schema.");
 
 		// Get the XML from the dumper into a string.
@@ -143,25 +144,25 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		} catch (XMLStreamException e) {
 			e.printStackTrace();
 		}
-		
-//		// Run the XML through a regexp to just get the parts we want.
-//		String output = null;
-//		//LOG.info("Current XML schema:\n" + config_string);
-//		Pattern pattern = Pattern.compile("<!--START-->(.*)<!--STOP-->", Pattern.DOTALL);
-//		Matcher matcher = pattern.matcher(config_string);
-//		boolean matchFound = matcher.find();
-//		if (matchFound) {
-//			output = matcher.group(1); // not the global match, but inside
-//			//LOG.info("Found:\n" + output);
-//		}
-		
-//		// Either we got it, and we dump to STDOUT, or exception.
-//		if( output == null || output.equals("") ){
-//			throw new Error();
-//		}else{
-//  		System.out.println(output);
+
+		//		// Run the XML through a regexp to just get the parts we want.
+		//		String output = null;
+		//		//LOG.info("Current XML schema:\n" + config_string);
+		//		Pattern pattern = Pattern.compile("<!--START-->(.*)<!--STOP-->", Pattern.DOTALL);
+		//		Matcher matcher = pattern.matcher(config_string);
+		//		boolean matchFound = matcher.find();
+		//		if (matchFound) {
+		//			output = matcher.group(1); // not the global match, but inside
+		//			//LOG.info("Found:\n" + output);
+		//		}
+
+		//		// Either we got it, and we dump to STDOUT, or exception.
+		//		if( output == null || output.equals("") ){
+		//			throw new Error();
+		//		}else{
+		//  		System.out.println(output);
 		System.out.println(config_string);
-//		}
+		//		}
 	}
 
 	/**
@@ -172,11 +173,11 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 */
 	@CLIMethod("--solr-url")
 	public void setSolrUrl(Opts opts) {
-	    opts.info("URL", "Note: pass 'mock' to create a mock loader (writes json docs to stdout");
+		opts.info("URL", "Note: pass 'mock' to create a mock loader (writes json docs to stdout");
 		globalSolrURL = opts.nextOpt(); // shift it off of null
 		LOG.info("Globally use GOlr server at: " + globalSolrURL);
 	}
-	
+
 	/**
 	 * Set an optional file to use for logging load data (can be consumed by AmiGO 2).
 	 * 
@@ -192,7 +193,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			LOG.info("Globally use GOlr log file: " + globalSolrLogFile.getAbsolutePath());
 		}
 	}
-	
+
 	/**
 	 * Manually purge the index to try again.
 	 * Since this cascade is currently ordered, can be used to purge before we load.
@@ -214,40 +215,40 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 
 		// Probably worked, so let's destroy the log if there is one.
 		if( globalSolrLogFile != null && globalSolrLogFile.exists() ){
-		    boolean yes_p = globalSolrLogFile.delete();
-		    if( yes_p ){
-		        LOG.info("Deleted GOlr load log file.");
-		    }else{
-		        // Nothing there, doing nothing.
-		    }
+			boolean yes_p = globalSolrLogFile.delete();
+			if( yes_p ){
+				LOG.info("Deleted GOlr load log file.");
+			}else{
+				// Nothing there, doing nothing.
+			}
 		}
 		LOG.info("Purged: " + url);
 	}
-	
-//	/**
-//	 * Used for loading whatever ontology stuff we have into GOlr.
-//	 * 
-//	 * @param opts 
-//	 * @throws Exception
-//	 */
-//	@Deprecated
-//	@CLIMethod("--solr-load-ontology-old")
-//	public void loadOntologySolr(Opts opts) throws Exception {
-//		// Check to see if the global url has been set.
-//		String url = sortOutSolrURL(globalSolrURL);				
-//
-//		// Actual ontology class loading.
-//		try {
-//			OntologySolrLoader loader = new OntologySolrLoader(url, g);
-//			loader.load();
-//		} catch (SolrServerException e) {
-//			LOG.info("Ontology load at: " + url + " failed!");
-//			e.printStackTrace();
-//		}
-//	}
-	
-	
-	
+
+	//	/**
+	//	 * Used for loading whatever ontology stuff we have into GOlr.
+	//	 * 
+	//	 * @param opts 
+	//	 * @throws Exception
+	//	 */
+	//	@Deprecated
+	//	@CLIMethod("--solr-load-ontology-old")
+	//	public void loadOntologySolr(Opts opts) throws Exception {
+	//		// Check to see if the global url has been set.
+	//		String url = sortOutSolrURL(globalSolrURL);				
+	//
+	//		// Actual ontology class loading.
+	//		try {
+	//			OntologySolrLoader loader = new OntologySolrLoader(url, g);
+	//			loader.load();
+	//		} catch (SolrServerException e) {
+	//			LOG.info("Ontology load at: " + url + " failed!");
+	//			e.printStackTrace();
+	//		}
+	//	}
+
+
+
 	/**
 	 * Flexible loader for ontologies--uses the YAML config to find loading functions.
 	 * 
@@ -256,7 +257,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 */
 	@CLIMethod("--solr-load-ontology")
 	public void flexLoadOntologySolr(Opts opts) throws Exception {
-	    opts.info("[--min-classes MIN] [--allow-null]", "Loads current in-memory graph as ontology documents using flex");
+		opts.info("[--min-classes MIN] [--allow-null]", "Loads current in-memory graph as ontology documents using flex");
 		// pre-check ontology
 		int code = preCheckOntology("Can't process an inconsistent ontology for solr", 
 				"Can't process an ontology with unsatisfiable classes for solr", null);
@@ -264,42 +265,42 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			exit(code);
 			return;
 		}
-		
+
 		boolean allowNullOntologies = false;
 		int minClasses = 100;
 		while (opts.hasOpts()) {
-            if (opts.nextEq("--min-classes")) {
-                opts.info("NUM", "exit with non-zero if fewer classes encountered");
-                minClasses = Integer.valueOf(opts.nextOpt());
-            }
-            else if (opts.nextEq("--allow-null")) {
-                opts.info("", "if set, empty ontologies (0 axioms, no IRI) will be ignored rather than failing");
-                allowNullOntologies = true;
-            }
-		    else {
-		        break;
-		    }
+			if (opts.nextEq("--min-classes")) {
+				opts.info("NUM", "exit with non-zero if fewer classes encountered");
+				minClasses = Integer.valueOf(opts.nextOpt());
+			}
+			else if (opts.nextEq("--allow-null")) {
+				opts.info("", "if set, empty ontologies (0 axioms, no IRI) will be ignored rather than failing");
+				allowNullOntologies = true;
+			}
+			else {
+				break;
+			}
 		}
-		
+
 		int numClasses = g.getAllOWLClasses().size();
 		if (numClasses < minClasses) {
-		    LOG.error("Fewer classes than expected: "+numClasses+" < "+minClasses);
-		    exit(1);
+			LOG.error("Fewer classes than expected: "+numClasses+" < "+minClasses);
+			exit(1);
 		}
-		
+
 		for (OWLOntology o : g.getAllOntologies()) {
-		    OWLOntologyID oid = o.getOntologyID();
-		    if (oid == null || !oid.getOntologyIRI().isPresent()) {
-		        if (o.getAxiomCount() == 0) {
-		            if (!allowNullOntologies) {
-		                LOG.error("Encountered null ontology: "+o);
-		                LOG.error("perhaps an ontology IRI is misconfigured?");
-		                LOG.error("run with --allow-null to ignore this");
-		                exit(1);
-		                
-		            }
-		        }
-		    }
+			OWLOntologyID oid = o.getOntologyID();
+			if (oid == null || !oid.getOntologyIRI().isPresent()) {
+				if (o.getAxiomCount() == 0) {
+					if (!allowNullOntologies) {
+						LOG.error("Encountered null ontology: "+o);
+						LOG.error("perhaps an ontology IRI is misconfigured?");
+						LOG.error("run with --allow-null to ignore this");
+						exit(1);
+
+					}
+				}
+			}
 		}
 
 		// Check to see if the global url has been set.
@@ -308,17 +309,17 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		// Grab the intermediate form.
 		LOG.info("Assembling FlexCollection...");
 		FlexCollection flex = new FlexCollection(aconf, g);
-		
-        boolean isMock = false;
+
+		boolean isMock = false;
 		int nClasses = 0;
 		// Actual ontology class loading.
 		FlexSolrDocumentLoader loader;
 		if (url.equals("mock")) {
-		    loader = new MockFlexSolrDocumentLoader(flex);
-		    isMock = true;
+			loader = new MockFlexSolrDocumentLoader(flex);
+			isMock = true;
 		}
 		else {
-		    loader = new FlexSolrDocumentLoader(url, flex);
+			loader = new FlexSolrDocumentLoader(url, flex);
 		}
 
 		LOG.info("Trying ontology flex load.");
@@ -327,8 +328,8 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		// number of docs loaded MUST be equal to or higher than minClasses
 		// (docs also comprises non-class documents, e.g. ObjectProperties)
 		if (loader.getCurrentDocNumber() < minClasses) {
-		    LOG.error("Fewer documents loaded than expected: "+loader.getCurrentDocNumber()+" < "+minClasses);
-		    exit(1);			    
+			LOG.error("Fewer documents loaded than expected: "+loader.getCurrentDocNumber()+" < "+minClasses);
+			exit(1);			    
 		}
 
 		// Load likely successful--log it.
@@ -337,59 +338,57 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		//for( OWLOntology o : g.getAllOntologies() ){
 		for( OWLOntology o : g.getManager().getOntologies() ){
 
-		    //optionallyLogLoad("ontology", o.getOntologyID().toString());
-		    // This is "correct", but I'm only getting one.
-		    String ont_id = "unknown";
-		    String ont_version = "unknown";
-		    try {
-		        if (o.getOntologyID() !=  null) {
-		            Optional<IRI> optional = o.getOntologyID().getOntologyIRI();
-		            if (optional.isPresent()) {
-		                ont_id = optional.get().toString();
-		            }
-		            else {
-		                LOG.info("Failed to get ID of: " + o.toString() + "!");
-		            }
-		        }
-		    } catch (NullPointerException e) {
-		        LOG.info("Failed to get ID of: " + o.toString() + "!");
-		    }
+			//optionallyLogLoad("ontology", o.getOntologyID().toString());
+			// This is "correct", but I'm only getting one.
+			String ont_id = "unknown";
+			String ont_version = "unknown";
+			try {
+				if (o.getOntologyID() !=  null) {
+					Optional<IRI> optional = o.getOntologyID().getOntologyIRI();
+					if (optional.isPresent()) {
+						ont_id = optional.get().toString();
+					}
+					else {
+						LOG.info("Failed to get ID of: " + o.toString() + "!");
+					}
+				}
+			} catch (NullPointerException e) {
+				LOG.info("Failed to get ID of: " + o.toString() + "!");
+			}
 
-		    try {
-		        Optional<IRI> versionIRI = o.getOntologyID().getVersionIRI();
-		        if (versionIRI.isPresent()){
-		            ont_version = versionIRI.get().toString();
-		            Pattern p = Pattern.compile("(\\d{4}-\\d{2}-\\d{2})");
-		            Matcher m = p.matcher(ont_version);
-		            m.find();
-		            ont_version = m.group(0);
-		            //ont_version = StringUtils.substringBetween(ont_version, "releases/", "/");
-		        }
-		        else {
-		            ont_version = null;
-		        }
-		        if( ont_version == null || ont_version.equals("") ){
-		            // Sane fallback.
-		            LOG.info("Failed to extract version of: " + ont_id + "!");
-		        }
-		    } catch (NullPointerException e) {
-		        LOG.info("Failed to get version of: " + ont_id + "!");
-		    } catch (IllegalStateException e) {
-		        LOG.info("Failed to get match for version of: " + ont_id + "!");
-		    }
-		    optionallyLogLoad("ontology", ont_id, ont_version);
+			try {
+				Optional<IRI> versionIRI = o.getOntologyID().getVersionIRI();
+				if (versionIRI.isPresent()){
+					ont_version = versionIRI.get().toString();
+					Pattern p = Pattern.compile("(\\d{4}-\\d{2}-\\d{2})");
+					Matcher m = p.matcher(ont_version);
+					m.find();
+					ont_version = m.group(0);
+					//ont_version = StringUtils.substringBetween(ont_version, "releases/", "/");
+				}
+				else {
+					ont_version = null;
+				}
+				if( ont_version == null || ont_version.equals("") ){
+					// Sane fallback.
+					LOG.info("Failed to extract version of: " + ont_id + "!");
+				}
+			} catch (NullPointerException e) {
+				LOG.info("Failed to get version of: " + ont_id + "!");
+			} catch (IllegalStateException e) {
+				LOG.info("Failed to get match for version of: " + ont_id + "!");
+			}
+			optionallyLogLoad("ontology", ont_id, ont_version);
 
-		    if (isMock) {
-		        showMockDocs((MockSolrDocumentLoader) loader);
-		    }
+			if (isMock) {
+				showMockDocs((MockSolrDocumentLoader) loader);
+			}
 
 		}
-		
+
 	}
-	
 
-
-    /**
+	/**
 	 * Trivial hard-wired (and optional) method for loading collected
 	 * ontology information into the "general" schema (general-config.yaml) for GO.
 	 * This is a very dumb, but easy to understand, loader.
@@ -408,7 +407,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		LOG.info("Trying ontology general load.");
 		loader.load();
 	}
-	
+
 	/**
 	 * Used for reading the ontology catalogs to be used for loading complex annotations.
 	 * 
@@ -442,7 +441,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			legoFiles.add(file);
 		}
 	}
-	
+
 	/**
 	 * Used for reading the lego files to be used for loading complex annotations.
 	 * 
@@ -451,20 +450,20 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	 */
 	@CLIMethod("--read-model-folder")
 	public void processModelFolder(Opts opts) throws Exception {
-	    // TODO - make cofigurable; 
-	    //see https://github.com/geneontology/minerva/commit/ebbe2937735a80dc7744e6cb516c5262755642e1
-	    String fileSuffix = "ttl"; 
+		// TODO - make cofigurable; 
+		//see https://github.com/geneontology/minerva/commit/ebbe2937735a80dc7744e6cb516c5262755642e1
+		String fileSuffix = "ttl"; 
 		legoFiles = new ArrayList<File>();
 		String modelFolderString = opts.nextOpt();
 		File modelFolder = new File(modelFolderString).getCanonicalFile();
 		File[] modelFiles = modelFolder.listFiles(new FilenameFilter() {
-		    final String fileSuffixFinal = fileSuffix;
+			final String fileSuffixFinal = fileSuffix;
 			@Override
 			public boolean accept(File dir, String name) {
-			    if (fileSuffixFinal != null && fileSuffixFinal.length() > 0)
-        	        return name.endsWith("."+fileSuffixFinal);
-			    else
-     		        return StringUtils.isAlphanumeric(name);
+				if (fileSuffixFinal != null && fileSuffixFinal.length() > 0)
+					return name.endsWith("."+fileSuffixFinal);
+				else
+					return StringUtils.isAlphanumeric(name);
 			}
 		});
 		Arrays.sort(modelFiles);
@@ -473,7 +472,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			legoFiles.add(modelFile);
 		}
 	}
-	
+
 	@CLIMethod("--read-model-url-prefix")
 	public void processModelUrlPrefix(Opts opts) throws Exception {
 		legoModelPrefix = opts.nextOpt();
@@ -501,15 +500,15 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			}
 		}
 	}
-	
+
 	@CLIMethod("--solr-load-models")
 	public void loadModelAnnotations(Opts opts) throws Exception {
 		Set<String> modelStateFilter = null;
 		boolean removeDeprecatedModels = false;
 		boolean removeTemplateModels = false;
-        boolean removeUnsatisfiableModels = false;
-        boolean exitIfUnsatisfiable = true;
-        boolean exitIfLoadFails = true;
+		boolean removeUnsatisfiableModels = false;
+		boolean exitIfUnsatisfiable = true;
+		boolean exitIfLoadFails = true;
 		while (opts.hasOpts()) {
 			if (opts.nextEq("--defaultModelStateFilter|--productionModelStateFilter")) {
 				if(modelStateFilter != null) { 
@@ -539,19 +538,18 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			else if (opts.nextEq("--excludeUnsatisfiableModels|--excludeUnsatisfiable")) {
 				removeUnsatisfiableModels = true;
 			}
-            else if (opts.nextEq("--includeUnsatisfiableModels|--includeUnsatisfiable")) {
-                removeUnsatisfiableModels = false;
-                exitIfUnsatisfiable = false;
-            }
-            else if (opts.nextEq("--noExitIfLoadFails")) {
-                opts.info("", "carry on if fail to load any individual model fails. Default is fail fast");
-                exitIfLoadFails = false;
-            }
+			else if (opts.nextEq("--includeUnsatisfiableModels|--includeUnsatisfiable")) {
+				removeUnsatisfiableModels = false;
+				exitIfUnsatisfiable = false;
+			}
+			else if (opts.nextEq("--noExitIfLoadFails")) {
+				opts.info("", "carry on if fail to load any individual model fails. Default is fail fast");
+				exitIfLoadFails = false;
+			}
 			else
 				break;
-
 		}
-		
+
 		// Check to see if the global url has been set.
 		String url = sortOutSolrURL(globalSolrURL);
 
@@ -588,14 +586,14 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 				OWLOntology model = null;
 				try {
 					model = pw.parseOWL(IRI.create(legoFile));
-					
+
 					//skip deprecated models
 					boolean isDeprecated = isDeprecated(model);
 					if (isDeprecated) {
 						LOG.warn("Skipping deprecated model: "+fname);
 						continue;
 					}
-					
+
 					// Some sanity checks--some of the generated ones are problematic.
 					currentReasoner = reasonerFactory.createReasoner(model);
 					boolean consistent = currentReasoner.isConsistent();
@@ -604,45 +602,47 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 						LOG.warn("Skip since inconsistent: " + fname);
 						continue;
 					}
-					
+
 					ModelAnnotationSolrDocumentLoader loader = null;
 					try {
 						LOG.info("Trying complex annotation load of: " + fname);
 						boolean isMock = false;
 						String modelUrl = legoModelPrefix + fname;
 						if (url.equals("mock")) {
-						    loader = new MockModelAnnotationSolrDocumentLoader(url, model, currentReasoner, modelUrl, 
-						            modelStateFilter, removeDeprecatedModels, removeTemplateModels);
-						    isMock = true;
+							loader = new MockModelAnnotationSolrDocumentLoader(url, model, currentReasoner, modelUrl, 
+									modelStateFilter, removeDeprecatedModels, removeTemplateModels);
+							isMock = true;
 						}
 						else {
-						    loader = new ModelAnnotationSolrDocumentLoader(url, model, currentReasoner, modelUrl, 
-						            modelStateFilter, removeDeprecatedModels, removeTemplateModels);
+							loader = new ModelAnnotationSolrDocumentLoader(url, model, currentReasoner, modelUrl, 
+									modelStateFilter, removeDeprecatedModels, removeTemplateModels);
 						}
 
 						loader.load();
-				        if (isMock) {
-				            showMockDocs((MockModelAnnotationSolrDocumentLoader) loader);
-				        }
 
+						if (isMock) {
+							showMockDocs((MockModelAnnotationSolrDocumentLoader) loader);
+						}
 					} catch (SolrServerException e) {
 						LOG.info("Complex annotation load of " + fname + " at " + url + " failed!");
 						e.printStackTrace();
-						if (exitIfLoadFails) {
-						    System.exit(1);
-						}
+						
+						if (exitIfLoadFails)
+							System.exit(1);
 					}
 					finally {
-						IOUtils.closeQuietly(loader);
+						if (loader != null)
+							loader.close();
 					}
+
+					HeapInfo.showHeapStatus();
 				} finally {
 					// Cleanup reasoner and ontology.
-					if (currentReasoner != null) {
+					if (currentReasoner != null)
 						currentReasoner.dispose();
-					}
-					if (model != null) {
+
+					if (model != null)
 						manager.removeOntology(model);
-					}
 				}
 			}
 			LOG.info("Finished loading models.");
@@ -702,7 +702,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			}
 			OWLOntologyManager manager = pw.getManager();
 			OWLReasonerFactory reasonerFactory = new ElkReasonerFactory();
-				
+
 			// Actual loading--iterate over our list and load individually.
 			for( File legoFile : legoFiles ){
 				String fname = legoFile.getName();
@@ -717,7 +717,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 				try {
 					ontology = pw.parseOWL(IRI.create(legoFile));
 					currentReasoner = reasonerFactory.createReasoner(ontology);
-						
+
 					// Some sanity checks--some of the genereated ones are problematic.
 					boolean consistent = currentReasoner.isConsistent();
 					if( consistent == false ){
@@ -725,13 +725,13 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 						continue;
 					}
 					Set<OWLClass> unsatisfiable = currentReasoner.getUnsatisfiableClasses().getEntitiesMinusBottom();
-					
+
 					// TODO - make configurable to allow fail fast
 					if (unsatisfiable.isEmpty() == false) {
 						LOG.info("Skip since unsatisfiable: " + fname);
 						continue;
 					}
-					
+
 					Set<OWLNamedIndividual> individuals = ontology.getIndividualsInSignature();
 					Set<OWLAnnotation> modelAnnotations = ontology.getAnnotations();
 					OWLGraphWrapper currentGraph = new OWLGraphWrapper(ontology);						
@@ -780,7 +780,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			// I wish there was an arcitecture diagram somehwere...
 			OWLOntologyManager manager = pw.getManager();
 			OWLReasonerFactory reasonerFactory = new ElkReasonerFactory();
-				
+
 			// Actual loading--iterate over our list and load individually.
 			for( String fname : caFiles ){
 				OWLReasoner currentReasoner = null;
@@ -792,11 +792,11 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 				String[] bits = StringUtils.split(pretmp, "/");
 				String agID = bits[bits.length -1];
 				String agLabel = new String(StringUtils.replaceOnce(agID, ":", "_"));
-				
+
 				try {
 					ontology = pw.parseOWL(IRI.create(fname));
 					currentReasoner = reasonerFactory.createReasoner(ontology);
-						
+
 					// Some sanity checks--some of the genereated ones are problematic.
 					boolean consistent = currentReasoner.isConsistent();
 					if( consistent == false ){
@@ -808,7 +808,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 						LOG.info("Skip since unsatisfiable: " + fname);
 						continue;
 					}
-					
+
 					Set<OWLNamedIndividual> individuals = ontology.getIndividualsInSignature();
 					Set<OWLAnnotation> modelAnnotations = ontology.getAnnotations();
 					OWLGraphWrapper currentGraph = new OWLGraphWrapper(ontology);						
@@ -845,17 +845,17 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	public void flexDumpOntologySolr(Opts opts) throws Exception {
 
 		//Logger.getRootLogger().setLevel(Level.ERROR);
-		
+
 		// Grab the intermediate form.
 		FlexCollection flex = new FlexCollection(aconf, g);
 
 		// TODO: Make it a little nicer?
-		
+
 		// And dump it.
 		Gson gson = new Gson();
 		System.out.println(gson.toJson(flex));
 	}
-		
+
 	/**
 	 * Used for loading a list of GAFs into GOlr.
 	 * 
@@ -896,15 +896,15 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 				break;
 
 		}
-		
+
 		// Check to see if the global url has been set.
 		String url = sortOutSolrURL(globalSolrURL);
-		
+
 		// We should already have added the reasoner elsewhere on the commandline,
 		// So there should be real no extra overhead here.
 		EcoTools eco = new EcoTools(g, g.getReasoner(), true);
 		TaxonTools taxo = new TaxonTools(g.getReasoner(), true);
-		
+
 		List<String> files = opts.nextList();
 		for (String file : files) {
 			LOG.info("Parsing GAF: [" + file + "]");
@@ -914,47 +914,47 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			}
 			gafdoc = builder.buildDocument(file);
 			loadGAFDoc(url, gafdoc, eco, taxo, pSet, taxonSubsetName, ecoSubsetName);
-			
+
 			// Load likely successful--log it.
 			optionallyLogLoad("gaf", file, "n/a");
 		}
-		
+
 		eco.dispose();
 		taxo.dispose();
 	}
-	
-//	/**
-//	 * Requires the --gaf argument (or something else that fills the gafdoc object).
-//	 * 
-//	 * @param opts
-//	 * @throws Exception
-//	 */
-//	@CLIMethod("--solr-load-gaf")
-//	public void loadGafSolr(Opts opts) throws Exception {
-//		// Double check we're not going to do something silly, like try and
-//		// use a null variable...
-//		if( gafdoc == null ){
-//			System.err.println("No GAF document defined (maybe use '--gaf GAF-FILE') ");
-//			exit(1);
-//		}
-//
-//		// We should already have added the reasoner elsewhere on the commandline,
-//		// So there should be real no extra overhead here.
-//		EcoTools eco = new EcoTools(g, g.getReasoner(), true);
-//		TaxonTools taxo = new TaxonTools(g, g.getReasoner(), true);
-//
-//		// Check to see if the global url has been set.
-//		String url = sortOutSolrURL(globalSolrURL);
-//		// Doc load.
-//		loadGAFDoc(url, gafdoc, eco, taxo, pSet);
-//
-//		// Load likely successful--log it.
-//		optionallyLogLoad("gaf", gafdoc.getId());
-//
-//		eco.dispose();
-//		taxo.dispose();
-//	}
-		
+
+	//	/**
+	//	 * Requires the --gaf argument (or something else that fills the gafdoc object).
+	//	 * 
+	//	 * @param opts
+	//	 * @throws Exception
+	//	 */
+	//	@CLIMethod("--solr-load-gaf")
+	//	public void loadGafSolr(Opts opts) throws Exception {
+	//		// Double check we're not going to do something silly, like try and
+	//		// use a null variable...
+	//		if( gafdoc == null ){
+	//			System.err.println("No GAF document defined (maybe use '--gaf GAF-FILE') ");
+	//			exit(1);
+	//		}
+	//
+	//		// We should already have added the reasoner elsewhere on the commandline,
+	//		// So there should be real no extra overhead here.
+	//		EcoTools eco = new EcoTools(g, g.getReasoner(), true);
+	//		TaxonTools taxo = new TaxonTools(g, g.getReasoner(), true);
+	//
+	//		// Check to see if the global url has been set.
+	//		String url = sortOutSolrURL(globalSolrURL);
+	//		// Doc load.
+	//		loadGAFDoc(url, gafdoc, eco, taxo, pSet);
+	//
+	//		// Load likely successful--log it.
+	//		optionallyLogLoad("gaf", gafdoc.getId());
+	//
+	//		eco.dispose();
+	//		taxo.dispose();
+	//	}
+
 	/**
 	 * Requires the --read-panther argument (or something else that fills the pSet object).
 	 * 
@@ -975,14 +975,14 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 
 		// Check to see if the global url has been set.
 		String url = sortOutSolrURL(globalSolrURL);
-		
+
 		// Doc load.
 		PANTHERSolrDocumentLoader loader = new PANTHERSolrDocumentLoader(url);
 		loader.setPANTHERSet(pSet);
 		loader.setGraph(g);
 		loader.load();
 	}
-		
+
 	/**
 	 * Requires the --read-panther argument (or something else that fills the pSet object).
 	 * 
@@ -1003,42 +1003,42 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 
 		// Check to see if the global url has been set.
 		String url = sortOutSolrURL(globalSolrURL);
-		
+
 		// Doc load.
 		PANTHERGeneralSolrDocumentLoader loader = new PANTHERGeneralSolrDocumentLoader(url);
 		loader.setPANTHERSet(pSet);
 		loader.setGraph(g);
 		loader.load();
 	}
-		
+
 	/**
 	 * Used for loading a list of GPAD pairs into GOlr.
 	 * 
 	 * @param opts
 	 * @throws Exception
 	 */
-//	@CLIMethod("--solr-load-gpads")
-//	public void loadGPADsSolr(Opts opts) throws Exception {
-//		// Check to see if the global url has been set.
-//		//String url = sortOutSolrURL(globalSolrURL);
-//
-//		List<String> files = opts.nextList();
-//		if( files.size() % 2 != 0 ){
-//			System.err.println("GPAD format comes in pairs; skipping...");
-//		}else{
-//			while( ! files.isEmpty() ){
-//				String car = files.remove(0);
-//				String cdr = files.remove(0);
-//				LOG.info("Parsing GPAD car: " + car);
-//				LOG.info("Parsing GPAD cdr: " + cdr);
-//				// TODO: a new buildDocument that takes the two GPAD arguments.
-//				//GafObjectsBuilder builder = new GafObjectsBuilder();
-//				//gafdoc = builder.buildDocument(car, cdr);
-//				//loadGAFDoc(url, gafdoc);
-//			}
-//		}
-//	}
-	
+	//	@CLIMethod("--solr-load-gpads")
+	//	public void loadGPADsSolr(Opts opts) throws Exception {
+	//		// Check to see if the global url has been set.
+	//		//String url = sortOutSolrURL(globalSolrURL);
+	//
+	//		List<String> files = opts.nextList();
+	//		if( files.size() % 2 != 0 ){
+	//			System.err.println("GPAD format comes in pairs; skipping...");
+	//		}else{
+	//			while( ! files.isEmpty() ){
+	//				String car = files.remove(0);
+	//				String cdr = files.remove(0);
+	//				LOG.info("Parsing GPAD car: " + car);
+	//				LOG.info("Parsing GPAD cdr: " + cdr);
+	//				// TODO: a new buildDocument that takes the two GPAD arguments.
+	//				//GafObjectsBuilder builder = new GafObjectsBuilder();
+	//				//gafdoc = builder.buildDocument(car, cdr);
+	//				//loadGAFDoc(url, gafdoc);
+	//			}
+	//		}
+	//	}
+
 	/**
 	 * Used for applying the panther trees to the currently data run.
 	 * This must be run before the command is given to load a GAF.
@@ -1054,30 +1054,30 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	@CLIMethod("--read-panther")
 	public void processPantherTrees(Opts opts) throws Exception {
 
-//		// The first argument must be the associated HMM data dump.
-//		String treeClassifications = opts.nextOpt();
-//		LOG.info("Using file for PANTHER labels/classifications: " + treeClassifications);
-//		File tcFile = new File(treeClassifications);		
-		
+		//		// The first argument must be the associated HMM data dump.
+		//		String treeClassifications = opts.nextOpt();
+		//		LOG.info("Using file for PANTHER labels/classifications: " + treeClassifications);
+		//		File tcFile = new File(treeClassifications);		
+
 		// The rest of the arguments are 
 		// Go through the listed directories and collect the PANTHER
 		// tree files.
 		String treeDir = opts.nextOpt();
 		//List<File> pFilesCollection = new ArrayList<File>();
-//		while( ! treeDirs.isEmpty() ){
-//			String tDirName = treeDirs.remove(0);
-//			LOG.info("Using directory for PANTHER tree discovery: " + tDirName );
-//			File pDir = new File(tDirName);
-//			//FileFilter pFileFilter = new WildcardFileFilter("PTHR*.tree");
-//			File[] pFiles = pDir.listFiles(pFileFilter);
-//			if( pFiles !=null ){
-//				for( File pFile : pFiles ){
-//					pFilesCollection.add(pFile);
-//					//LOG.info("Processing PANTHER tree: " + pFile.getAbsolutePath());
-//				}			
-//			}
-//		}
-		
+		//		while( ! treeDirs.isEmpty() ){
+		//			String tDirName = treeDirs.remove(0);
+		//			LOG.info("Using directory for PANTHER tree discovery: " + tDirName );
+		//			File pDir = new File(tDirName);
+		//			//FileFilter pFileFilter = new WildcardFileFilter("PTHR*.tree");
+		//			File[] pFiles = pDir.listFiles(pFileFilter);
+		//			if( pFiles !=null ){
+		//				for( File pFile : pFiles ){
+		//					pFilesCollection.add(pFile);
+		//					//LOG.info("Processing PANTHER tree: " + pFile.getAbsolutePath());
+		//				}			
+		//			}
+		//		}
+
 		// Process the files and ready them for use in the Loader.
 		File pDir = new File(treeDir);
 		pSet = new PANTHERForest(pDir);
@@ -1087,7 +1087,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 	@CLIMethod("--solr-taxon-subset-name")
 	public void solrTaxonSubsetName(Opts opts) throws Exception {
 		taxonSubsetName = opts.nextOpt();
-		
+
 	}
 
 	@CLIMethod("--solr-eco-subset-name")
@@ -1108,12 +1108,12 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 
 		// Check to see if the global url has been set.
 		String url = sortOutSolrURL(globalSolrURL);
-		
+
 		// Doc load.
 		OptimizeSolrDocumentLoader optimizer = new OptimizeSolrDocumentLoader(url);
 		optimizer.load();
 	}
-	
+
 	/**
 	 * Used for generating output for units tests in other languages.
 	 * Output some JSON graph serializations.
@@ -1180,7 +1180,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		if( url == null ){
 			throw new Exception();
 		}
-		
+
 		return url;
 	}
 
@@ -1193,7 +1193,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		String now = df.format(new Date());
 		return now;
 	}
-	
+
 	/*
 	 * Log out the URL, type, and date. 
 	 */
@@ -1215,7 +1215,7 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			LOG.info("Skip logging: No GOlr load log specified.");			
 		}
 	}
-	
+
 	/*
 	 * Wrapper multiple places where there is direct GAF loading.
 	 */
@@ -1228,16 +1228,16 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 			LOG.warn("Huh, it looks like I'm going to skip an empty GAF...");// + gafdoc.getDocumentPath());
 			return;
 		}
-		
+
 		// Doc load.
 		boolean isMock = false;
 		GafSolrDocumentLoader loader;
 		if (url.equals("mock")) {
-		    loader = new MockGafSolrDocumentLoader();
-		    isMock = true;
+			loader = new MockGafSolrDocumentLoader();
+			isMock = true;
 		}
 		else {
-		    loader = new GafSolrDocumentLoader(url);
+			loader = new GafSolrDocumentLoader(url);
 		}
 		loader.setEcoTools(eco);
 		loader.setTaxonTools(taxo);
@@ -1249,17 +1249,17 @@ public class SolrCommandRunner extends TaxonCommandRunner {
 		LOG.info("Loading server at: " + url + " with: " + gafdoc.getDocumentPath());
 		loader.load();
 
-        if (isMock) {
-            showMockDocs((MockSolrDocumentLoader) loader);
-        }
+		if (isMock) {
+			showMockDocs((MockSolrDocumentLoader) loader);
+		}
 	}
-	
-	   // intended for debugging
-    private void showMockDocs(MockSolrDocumentLoader loader) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        for (Map<String, Object> d : loader.getDocumentCollection().getDocuments()) {
-            String json = gson.toJson(d);
-            System.out.println(json);                  
-        }
-    }
+
+	// intended for debugging
+	private void showMockDocs(MockSolrDocumentLoader loader) {
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		for (Map<String, Object> d : loader.getDocumentCollection().getDocuments()) {
+			String json = gson.toJson(d);
+			System.out.println(json);                  
+		}
+	}
 }

--- a/OWLTools-Solr/src/main/java/owltools/solrj/ModelAnnotationSolrDocumentLoader.java
+++ b/OWLTools-Solr/src/main/java/owltools/solrj/ModelAnnotationSolrDocumentLoader.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.commons.lang.SerializationUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrServer;
@@ -76,10 +77,10 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 	private final OWLAnnotationProperty layoutHintX;
 	private final OWLAnnotationProperty layoutHintY;
 	private final OWLAnnotationProperty templatestate;
-	
+
 	private final OWLAnnotationProperty displayLabelProp;
 	private final OWLAnnotationProperty shortIdProp;
-	
+
 	private final OWLAnnotationProperty jsonProp;
 
 	private final Set<OWLClass> bpSet;
@@ -91,7 +92,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			Set<String> modelFilter, boolean skipDeprecatedModels, boolean skipTemplateModels) throws MalformedURLException {
 		this(createDefaultServer(golrUrl), model, r, modelUrl, modelFilter, skipDeprecatedModels, skipTemplateModels);
 	}
-	
+
 	public ModelAnnotationSolrDocumentLoader(SolrServer server, OWLOntology model, OWLReasoner r, String modelUrl, 
 			Set<String> modelFilter, boolean skipDeprecatedModels, boolean skipTemplateModels) {
 		super(server);
@@ -106,12 +107,12 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		OWLDataFactory df = graph.getDataFactory();
 		partOf = OBOUpperVocabulary.BFO_part_of.getObjectProperty(df);
 		occursIn = OBOUpperVocabulary.BFO_occurs_in.getObjectProperty(df);
-		
+
 		defaultClosureRelations = new ArrayList<String>(1);
 		defaultClosureRelations.add(graph.getIdentifier(partOf));
-		
+
 		enabledBy = OBOUpperVocabulary.GOREL_enabled_by.getObjectProperty(df);
-		
+
 		title = df.getOWLAnnotationProperty(IRI.create("http://purl.org/dc/elements/1.1/title"));
 		source = df.getOWLAnnotationProperty(IRI.create("http://purl.org/dc/elements/1.1/source"));
 		contributor = df.getOWLAnnotationProperty(IRI.create("http://purl.org/dc/elements/1.1/contributor"));
@@ -123,12 +124,12 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		layoutHintX = df.getOWLAnnotationProperty(IRI.create("http://geneontology.org/lego/hint/layout/x"));
 		layoutHintY = df.getOWLAnnotationProperty(IRI.create("http://geneontology.org/lego/hint/layout/y"));
 		templatestate = df.getOWLAnnotationProperty(IRI.create("http://geneontology.org/lego/templatestate"));
-		
+
 		displayLabelProp = df.getRDFSLabel();
 		shortIdProp = df.getOWLAnnotationProperty(IRI.create(Obo2OWLConstants.OIOVOCAB_IRI_PREFIX+"id"));
-		
+
 		jsonProp = df.getOWLAnnotationProperty(IRI.create("http://geneontology.org/lego/json-model"));
-		
+
 		bpSet = getAspect(graph, "biological_process");
 	}
 
@@ -149,13 +150,13 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		}
 		return result;
 	}
-	
+
 	@Override
 	public void close() throws IOException {
 		graph.close();
-        if (reasoner != null) {
-            reasoner.dispose();
-        }
+		if (reasoner != null) {
+			reasoner.dispose();
+		}
 
 	}
 
@@ -163,7 +164,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 	public void load() throws SolrServerException, IOException {
 		LOG.info("Loading complex annotation document...");
 		final OWLShuntGraph shuntGraph = createShuntGraph(graph);
-		
+
 		String modelId = null;
 		String modelDate = null;
 		String title = null;
@@ -214,7 +215,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			// fallback
 			modelId = model.getOntologyID().getOntologyIRI().get().toString();
 		}
-		
+
 		if (requiredModelStates != null && state != null) {
 			boolean contains = requiredModelStates.contains(state);
 			if (contains == false) {
@@ -282,7 +283,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		addAllAndCommit();
 		LOG.info("Done.");
 	}
-	
+
 	private void addDoc(SolrInputDocument doc) throws SolrServerException, IOException {
 		if( doc != null ){
 			add(doc);
@@ -294,7 +295,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			}
 		}
 	}
-	
+
 	private Set<OWLAnnotation> getAnnotations(OWLAxiom ax, OWLNamedIndividual i) {
 		Set<OWLAnnotation> all = new HashSet<OWLAnnotation>();
 		if (ax != null) {
@@ -330,7 +331,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		}
 		return result;
 	}
-	
+
 	private Map<OWLClass, Pair<OWLNamedIndividual, Set<OWLAnnotation>>> findLocations(OWLNamedIndividual mf) {
 		Map<OWLClass, Pair<OWLNamedIndividual, Set<OWLAnnotation>>> result = new HashMap<OWLClass, Pair<OWLNamedIndividual,Set<OWLAnnotation>>>();
 		Set<OWLObjectPropertyAssertionAxiom> axioms = model.getObjectPropertyAssertionAxioms(mf);
@@ -349,7 +350,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		}
 		return result;
 	}
-	
+
 	private Set<OWLClass> getTypes(OWLNamedIndividual i) {
 		final Set<OWLClass> results = new HashSet<OWLClass>();
 		if (reasoner != null && reasoner.isConsistent()) {
@@ -372,7 +373,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 				}
 			}
 		}
-		
+
 		return results;
 	}
 
@@ -410,7 +411,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		return result;
 	}
 
-	private static String getLiteralValue(OWLAnnotationValue v) {
+	private static String getLiteralValue(OWLAnnotationValue v) {		
 		String literal = v.accept(new OWLAnnotationValueVisitorEx<String>() {
 			@Override
 			public String visit(IRI iri) {
@@ -427,19 +428,21 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 				return literal.getLiteral();
 			}
 		});
-		return literal;
+
+		// Cloning is made for avoiding memory leaks.
+		return (String) SerializationUtils.clone(literal);
 	}
 
 	private OWLShuntGraph createShuntGraph(OWLGraphWrapper graph) {
 		// Assemble the group shunt graph from available information.
 		// Most of the interesting stuff is happening with the meta-information.
 		OWLShuntGraph shuntGraph = new OWLShuntGraph();
-		
+
 		OWLOntology source = graph.getSourceOntology();
 		OWLPrettyPrinter pp = new OWLPrettyPrinter(graph);
-		
+
 		Set<OWLNamedIndividual> relevant = new HashSet<OWLNamedIndividual>();
-		
+
 		// links
 		Set<OWLObjectPropertyAssertionAxiom> objectPropertyAxioms = source.getAxioms(AxiomType.OBJECT_PROPERTY_ASSERTION);
 		for(OWLObjectPropertyAssertionAxiom ax : objectPropertyAxioms) {
@@ -454,7 +457,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 				String objectId = objectNamed.getIRI().toString();
 				relevant.add(objectNamed);
 				String propId = graph.getIdentifier(property.asOWLObjectProperty());
-				
+
 				OWLShuntEdge shuntEdge = new OWLShuntEdge(subjectId, objectId, propId);
 				shuntEdge.setMetadata(renderAnnotations(ax.getAnnotations()));
 				shuntGraph.addEdge(shuntEdge);
@@ -464,7 +467,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		// nodes
 		for(OWLNamedIndividual individual : relevant) {
 			String nodeId = individual.getIRI().toString();
-			
+
 			final StringBuilder sb = new StringBuilder();
 			Set<OWLClassAssertionAxiom> declaredTypes = source.getClassAssertionAxioms(individual);
 			for (OWLClassAssertionAxiom ax : declaredTypes) {
@@ -475,7 +478,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 				sb.append(pp.render(classExpression));
 			}
 			OWLShuntNode shuntNode = new OWLShuntNode(nodeId, sb.toString());
-			
+
 			Set<OWLAnnotationAssertionAxiom> annotationAxioms = source.getAnnotationAssertionAxioms(individual.getIRI());
 			shuntNode.setMetadata(renderAnnotationAxioms(annotationAxioms));
 			shuntGraph.addNode(shuntNode);
@@ -484,28 +487,26 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 	}
 
 	private String getLabel(OWLObject oc, OWLGraphWrapper graph){
-		String label = "???";
-		if( oc != null ){
-			label = graph.getAnnotationValue(oc, displayLabelProp);
-			if( label == null ){
-				label = getId(oc, graph);
-			}
-		}
-		
+		String label; 
+		if( oc == null ) return "???";
+
+		label = graph.getAnnotationValue(oc, displayLabelProp);
+		if( label == null )
+			label = getId(oc, graph);
+
 		return label;
 	}
 
 	private String getId(OWLObject cls, OWLGraphWrapper graph) {
-		String shortId = "???";
-		if (cls != null) {
-			shortId = graph.getAnnotationValue(cls, shortIdProp);
-			if (shortId == null) {
-				shortId = graph.getIdentifier(cls);
-			}
-		}
+		String shortId;
+		if (cls == null) return "???";
+
+		shortId = graph.getAnnotationValue(cls, shortIdProp);
+		if (shortId == null)
+			shortId = graph.getIdentifier(cls);
 		return shortId;
 	}
-	
+
 	static void addField(SolrInputDocument doc, String field, Object value) {
 		if (value != null && field != null) {
 			doc.addField(field, value);
@@ -546,7 +547,6 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			String modelId, String title, String state, String modelDate, String modelUrl, 
 			Set<String> modelAnnotations, String modelComment, OWLShuntGraph shuntGraph,
 			String jsonModel) {
-
 		final Set<String> allComments = new HashSet<String>(); // unused until schema can be fixed
 		if (modelComment != null) {
 			allComments.add(modelComment);
@@ -556,13 +556,13 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		OWLClass ecoClass = null; // Why do we only have one eco class, we have multiple annotations?
 		final Set<String> allReferences = new HashSet<String>();
 		final Set<String> allWiths = new HashSet<String>();
-		
+
 		ecoClass = processAnnotations(gpAnnotations, ecoClass, allReferences, allWiths, allComments, allContributors, allOtherAnnotationValues);
 		ecoClass = processAnnotations(mfAnnotations, ecoClass, allReferences, allWiths, allComments, allContributors, allOtherAnnotationValues);
 		ecoClass = processAnnotations(bpAnnotations, ecoClass, allReferences, allWiths, allComments, allContributors, allOtherAnnotationValues);
-		
+
 		final SolrInputDocument doc = new SolrInputDocument();
-		
+
 		final String gpId = getId(gpType, graph);
 		final String gpLabel = getLabel(gpType, graph);
 		final String mfId = getId(mfType, graph);
@@ -571,9 +571,8 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		final Set<String> mfClosure = mfClosureMap.keySet();
 		final Set<String> mfClosureLabel = new HashSet<String>(mfClosureMap.values());
 
-
 		doc.addField("document_category", "model_annotation");
-		
+
 		StringBuilder unitIdBuilder = new StringBuilder(modelId);
 		unitIdBuilder.append('|').append(gp.getIRI()).append('|').append(gpId).append('|').append(mfId).append('|');
 		if (bpType != null) {
@@ -589,7 +588,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		//  - id: id
 		//    description: A unique (and internal) thing.
 		doc.addField("id", unitId);
-		
+
 		//  - id: annotation_unit
 		//    type: string
 		doc.addField("annotation_unit", unitId);
@@ -702,7 +701,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		//    searchable: true
 		addField(doc, "function_class_closure_label", mfClosureLabel);
 		addField(doc, "function_class_closure_label_searchable", mfClosureLabel);
-		
+
 		addField(doc, "function_class_closure_map", mfClosureMap);
 
 		//## Process
@@ -717,7 +716,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			//    display_name: Process
 			//    type: string
 			addField(doc, "process_class", bpId);
-	
+
 			//  - id: process_class_label
 			//    description: Common process name.
 			//    display_name: Process
@@ -725,13 +724,13 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			//    searchable: true
 			addField(doc, "process_class_label", bpLabel);
 			addField(doc, "process_class_label_searchable", bpLabel);
-	
+
 			//  - id: process_class_closure
 			//    display_name: Process
 			//    type: string
 			//    cardinality: multi
 			addField(doc, "process_class_closure", bpClosure);
-	
+
 			//  - id: process_class_closure_label
 			//    display_name: Process
 			//    type: string
@@ -739,7 +738,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			//    searchable: true
 			addField(doc, "process_class_closure_label", bpClosureLabels);
 			addField(doc, "process_class_closure_label_searchable", bpClosureLabels);
-			
+
 			addField(doc, "process_class_closure_map", bpClosureMap);
 		}
 
@@ -782,17 +781,17 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			//    type: string
 			//    cardinality: multi
 			addField(doc, "location_list_closure_label", locationClosureLabels);
-			
+
 			addField(doc, "location_list_closure_map", locationClosureMap);
 		}
-		
+
 		//  - id: owl_blob_json
 		//    type: string
 		//    indexed: false
 		if (jsonModel != null) {
 			addField(doc, "owl_blob_json", jsonModel);
 		}
-		
+
 		//## Topology
 		//  - id: topology_graph_json
 		//    description: JSON blob form of the local stepwise topology graph.
@@ -800,7 +799,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		//    type: string
 		//    indexed: false
 		addField(doc, "topology_graph_json", shuntGraph.toJSON());
-
+		
 		//## Evidence and related
 		if (ecoClass != null) {
 			String evidenceId = getId(ecoClass, graph);
@@ -808,29 +807,29 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			Map<String, String> evidenceClosureMap = graph.getRelationClosureMap(ecoClass, defaultClosureRelations);
 			Set<String> evidenceClosure = evidenceClosureMap.keySet();
 			Set<String> evidenceClosureLabels = new HashSet<String>(evidenceClosureMap.values());
-			
+
 			//  - id: evidence_type
 			//    description: "Evidence type."
 			//    display_name: Evidence
 			//    type: string
 			addField(doc, "evidence_type", evidenceId);
-			
+
 			//label
 			addField(doc, "evidence_type_label", evidenceLabel);
 			addField(doc, "evidence_type_label_searchable", evidenceLabel);
-			
+
 			//  - id: evidence_type_closure
 			//    description: "All evidence (evidence closure) for this annotation"
 			//    display_name: Evidence type
 			//    type: string
 			//    cardinality: multi
 			addField(doc, "evidence_type_closure", evidenceClosure);
-			
+
 			addField(doc, "evidence_type_closure_label", evidenceClosureLabels);
 			addField(doc, "evidence_type_closure_label_searchable", evidenceClosureLabels);
-			
+
 			addField(doc, "evidence_type_closure_map", evidenceClosureMap);
-			
+
 			//  - id: evidence_with
 			//    description: "Evidence with/from."
 			//    display_name: Evidence with
@@ -838,7 +837,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			//    cardinality: multi
 			addField(doc, "evidence_with", allWiths);
 			addField(doc, "evidence_with_searchable", allWiths);
-			
+
 			//  - id: reference
 			//    description: "Database reference."
 			//    display_name: Reference
@@ -848,6 +847,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			addField(doc, "reference_searchable", allReferences);
 		}
 
+		
 		//  - id: comment
 		//    display_name: comment
 		//    type: string
@@ -855,7 +855,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		//    searchable: true
 		addField(doc, "comment", modelComment);
 		addField(doc, "comment_searchable", modelComment);
-		
+
 		//  - id: contributor
 		//    display_name: contributor
 		//    type: string
@@ -872,7 +872,7 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 		addField(doc, "annotation_value", allOtherAnnotationValues);
 		return doc;
 	}
-	
+
 	OWLClass processAnnotations(final Set<OWLAnnotation> annotations, OWLClass eco, 
 			final Set<String> allReferences, final Set<String> allWiths, final Set<String> allComments,
 			final Set<String> allContributors, final Set<String> allOtherAnnotationValues) {
@@ -981,5 +981,4 @@ public class ModelAnnotationSolrDocumentLoader extends AbstractSolrLoader implem
 			}
 		});
 	}
-
 }


### PR DESCRIPTION
This patch is for solving the memory leak issue that arises while generating solr indexes from go-cam model files. 
 - Problem: Loading each model file involves (i) retrieving some literal values from ontology objects and (ii) materializing implicit axioms. These literals and axioms are later directly referenced and fed into the object used for solr document objects. The problem is that, even if we put codes that remove ontology objects, garbage collectors in Java skipped releasing the literals and the axioms because they are still in use,  therefore all connected objects still stay in memory. 

 - Solution: I cloned new objects from reasoning and reasoner objects (and then dispose them once they are converted them as solr index entries).

 - I believe similar issues would arise for many other parts of owltools but I minimally fixed the codes to avoid any other potential bugs for now.