### PR TITLE
Revised getIdentifier method to use oboInOwl#id for non-obolibrary PURLs

### DIFF
--- a/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperExtended.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperExtended.java
@@ -11,6 +11,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.obolibrary.obo2owl.Obo2OWLConstants.Obo2OWLVocabulary;
+import org.apache.commons.lang.SerializationUtils;
+import org.apache.log4j.Logger;
 import org.geneontology.obographs.io.OgJsonGenerator;
 import org.geneontology.obographs.model.GraphDocument;
 import org.geneontology.obographs.owlapi.FromOwl;
@@ -47,6 +49,7 @@ import org.semanticweb.owlapi.model.OWLReflexiveObjectPropertyAxiom;
 import org.semanticweb.owlapi.model.OWLSymmetricObjectPropertyAxiom;
 import org.semanticweb.owlapi.model.OWLTransitiveObjectPropertyAxiom;
 import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.OWLObjectVisitorExAdapter;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
@@ -65,7 +68,7 @@ import owltools.util.OwlHelper;
  * @see OWLGraphWrapperBasic
  */
 public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
-
+	private static final Logger LOG = Logger.getLogger(OWLGraphWrapperExtended.class);
 	private Map<String,OWLObject> altIdMap = null;
 
 	protected OWLGraphWrapperExtended(OWLOntology ontology) {
@@ -878,19 +881,48 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 		return getIdentifier(owlObject);
 	}
 
-
 	/**
-	 * gets the OBO-style ID of the specified object. E.g. "GO:0008150"
+	 * gets the OBO-style ID of the specified object. e.g., "GO:0008150"
+	 * SerializationUtils.clone is used to avoid memory leaks.
 	 * 
 	 * @param iriId
-	 * @return OBO-style identifier, using obo2owl mapping
+	 * @return OBO-style identifier, using obo2owl mappings or the literals extracted from oboInowl#id.
 	 */
 	public String getIdentifier(IRI iriId) {
-		return Owl2Obo.getIdentifier(iriId);
+		if (iriId.toString().startsWith(Obo2OWLConstants.DEFAULT_IRI_PREFIX))
+			return (String) SerializationUtils.clone(Owl2Obo.getIdentifier(iriId));
+
+		final OWLAnnotationProperty oboIdInOwl = getDataFactory().getOWLAnnotationProperty(Obo2Owl.trTagToIRI(OboFormatTag.TAG_ID.getTag()));
+		OWLClass oc = getOWLClass(iriId);
+		for (OWLOntology o : getAllOntologies()) {
+			for (OWLAnnotation oa: EntitySearcher.getAnnotations(oc.getIRI(), o)) {
+				if (oa.getProperty().equals(oboIdInOwl) != true) 
+					continue;
+
+				OWLAnnotationValue objValue = oa.getValue();
+				if (objValue.isLiteral() != true) {
+					LOG.warn(objValue + " is supposed to be an literal, but it is not?!");
+					continue;
+				}
+
+				Optional<OWLLiteral> literalOpt = objValue.asLiteral();
+				if (literalOpt.isPresent() != true) {
+					LOG.warn("Is the literal value of oboInOw#id, " + objValue + ", null?");
+					continue;
+				}
+
+				OWLLiteral literal = literalOpt.get();
+				return (String) SerializationUtils.clone(literal.getLiteral().trim());
+			}
+		} 
+
+		throw new RuntimeException("The IRI " + iriId + " does not start with the obolib prefix nor have any oboInOw#id?!");
 	}
+
 	public IRI getIRIByIdentifier(String id) {
 		return getIRIByIdentifier(id, false);
 	}
+
 	public IRI getIRIByIdentifier(String id, boolean isAutoResolve) {
 		if (isAutoResolve) {
 			OWLObject obj = this.getObjectByAltId(id);

--- a/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperExtended.java
+++ b/OWLTools-Core/src/main/java/owltools/graph/OWLGraphWrapperExtended.java
@@ -912,7 +912,7 @@ public class OWLGraphWrapperExtended extends OWLGraphWrapperBasic {
 				}
 
 				OWLLiteral literal = literalOpt.get();
-				return (String) SerializationUtils.clone(literal.getLiteral().trim());
+				return (String) SerializationUtils.clone(literal.getLiteral());
 			}
 		} 
 

--- a/OWLTools-Core/src/test/java/owltools/graph/OWLGraphWrapperExtendedTest.java
+++ b/OWLTools-Core/src/test/java/owltools/graph/OWLGraphWrapperExtendedTest.java
@@ -35,4 +35,17 @@ public class OWLGraphWrapperExtendedTest  extends OWLToolsTestBasics {
 		thrown.expectMessage("Multiple candidate IRIs are found for id: dummy2. None of them are from BFO or RO.");
 		wrapper.getIRIByIdentifier("dummy2", false);
 	}
+
+	@Test
+	public void testGetIdentifier() throws Exception {
+		OWLGraphWrapper wrapper = getGraph("graph/dummy-ontology.owl");
+
+		String id1 = wrapper.getIdentifier(IRI.create("http://purl.obolibrary.org/obo/GO_0000001"));
+		String id2 = wrapper.getIdentifier(IRI.create("http://purl.obolibrary.org/obo/GO_0000002"));
+		String id3 = wrapper.getIdentifier(IRI.create("http://example.com/X_005"));
+
+		assertEquals(id1, "GO:0000001");
+		assertEquals(id2, "GO:0000002");
+		assertEquals(id3, "X:5");
+	}
 }

--- a/OWLTools-Core/src/test/resources/graph/dummy-ontology.owl
+++ b/OWLTools-Core/src/test/resources/graph/dummy-ontology.owl
@@ -12,7 +12,7 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:ace_lexicon="http://attempto.ifi.uzh.ch/ace_lexicon#"
-     xmlns:obo="http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:foaf="http://xmlns.com/foaf/0.1/"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
 

--- a/OWLTools-Core/src/test/resources/graph/dummy-ontology.owl
+++ b/OWLTools-Core/src/test/resources/graph/dummy-ontology.owl
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/mondo.owl#"
+     xml:base="http://purl.obolibrary.org/obo/mondo.owl"
+     xmlns:mondo="http://purl.obolibrary.org/obo/mondo#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:obo1="http://purl.obolibrary.org/obo/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:ncbitaxon="http://purl.obolibrary.org/obo/ncbitaxon#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:ace_lexicon="http://attempto.ifi.uzh.ch/ace_lexicon#"
+     xmlns:obo="http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id"/>
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0000001">
+    </owl:Class>
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0000002">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAKE:1234</oboInOwl:id>
+    </owl:Class>
+
+    <owl:Class rdf:about="http://example.com/X_005">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">X:5</oboInOwl:id>
+    </owl:Class>
+</rdf:RDF>


### PR DESCRIPTION
* This pull request contains patches that resolve the issue discussed in [this post](https://github.com/owlcollab/owltools/issues/245). I also added testcase codes based on the example ontology snippet in that post and confirmed that the codes properly handle all cases discussed. Thank you.