### PR TITLE
Bash fixes for Mac (10.12) compatibility

### DIFF
--- a/OWLTools-Runner/bin/owltools.script
+++ b/OWLTools-Runner/bin/owltools.script
@@ -1,8 +1,22 @@
 #!/bin/bash
-# Path to this script/jar
-PATH_TO_SELF=`which $0`
-MY_NAME=`basename $0`
-MY_DIR=`dirname $0`
+
+IS_MAC="FALSE"
+if uname | grep -iq Darwin; then
+	IS_MAC="TRUE"
+fi
+	
+if [ $IS_MAC = "TRUE" ]
+then
+	# Path to this script/jar
+	PATH_TO_SELF=`which "$0"`
+	MY_NAME=`basename "$0"`
+	MY_DIR=`dirname "$0"`
+else
+	# Path to this script/jar
+	PATH_TO_SELF=`which $0`
+	MY_NAME=`basename $0`
+	MY_DIR=`dirname $0`
+fi	
 
 # Add possibly existing java args from $MY_NAME.vmoptions file or env var
 if [ -e "$PATH_TO_SELF.vmoptions" ]
@@ -21,7 +35,12 @@ fi
 JAVA=`which java`
 
 # full command
-CMD="$JAVA -Xms2G $JVM_OPTIONS -DentityExmpansionLimit=4086000 -Djava.awt.headless=true -classpath $PATH_TO_SELF owltools.cli.CommandLineInterface"
+if [ $IS_MAC = "TRUE" ]
+then
+	CMD="$JAVA -Xms2G $JVM_OPTIONS -DentityExmpansionLimit=4086000 -Djava.awt.headless=true -classpath \"$MY_DIR/owltools-oort-all.jar:$MY_DIR/owltools-runner-all.jar\" owltools.cli.CommandLineInterface"
+else
+	CMD="$JAVA -Xms2G $JVM_OPTIONS -DentityExmpansionLimit=4086000 -Djava.awt.headless=true -classpath $PATH_TO_SELF owltools.cli.CommandLineInterface"
+fi
 
 if [ $DEBUG ]
 then
@@ -29,6 +48,11 @@ then
 fi
 
 # Run
-exec "$JAVA" -Xms2G $JVM_OPTIONS -DentityExmpansionLimit=4086000 -Djava.awt.headless=true -classpath $PATH_TO_SELF owltools.cli.CommandLineInterface "$@"
+if [ $IS_MAC = "TRUE" ]
+then
+	exec "$JAVA" -Xms2G $JVM_OPTIONS -DentityExmpansionLimit=4086000 -Djava.awt.headless=true -classpath "$MY_DIR/owltools-oort-all.jar:$MY_DIR/owltools-runner-all.jar" owltools.cli.CommandLineInterface "$@"
+else
+	exec "$JAVA" -Xms2G $JVM_OPTIONS -DentityExmpansionLimit=4086000 -Djava.awt.headless=true -classpath $PATH_TO_SELF owltools.cli.CommandLineInterface "$@"
+fi
 
 exit 1


### PR DESCRIPTION
I was unable to run owltools on the Mac (OS X 10.12). The following changes were required. 

Note that I did not test this on any other systems but I added a test to the script see if it's running on a Mac and if so then the following changes are implemented. If not running on a Mac then there should be no change in behavior. 

1. Need double quotes around $0.
2. Need to include jar files in class path.
3. Used MY_DIR instead of PATH_TO_SELF in classpath.