### PR TITLE
Use -jar option to run from embedded jar. Possible fix for #256.

### DIFF
--- a/OWLTools-Runner/bin/owltools.script
+++ b/OWLTools-Runner/bin/owltools.script
@@ -21,7 +21,7 @@ fi
 JAVA=`which java`
 
 # full command
-CMD="$JAVA -Xms2G $JVM_OPTIONS -DentityExpansionLimit=4086000 -Djava.awt.headless=true -classpath $PATH_TO_SELF owltools.cli.CommandLineInterface"
+CMD="$JAVA -Xms2G $JVM_OPTIONS -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar $PATH_TO_SELF"
 
 if [ $DEBUG ]
 then
@@ -29,6 +29,6 @@ then
 fi
 
 # Run
-exec "$JAVA" -Xms2G $JVM_OPTIONS -DentityExpansionLimit=4086000 -Djava.awt.headless=true -classpath $PATH_TO_SELF owltools.cli.CommandLineInterface "$@"
+exec "$JAVA" -Xms2G $JVM_OPTIONS -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar $PATH_TO_SELF "$@"
 
 exit 1


### PR DESCRIPTION
owltools produces different output from `--save-closure-for-chado` on different machines (Mac vs Linux) when running from jar embedded in script. Using the jar directly with `java -jar` seems to work the same on both.