### PR TITLE
Update many dependencies

### DIFF
--- a/Golr-Client/pom.xml
+++ b/Golr-Client/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.6</version>
+			<version>4.5.12</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/Lego/pom.xml
+++ b/Lego/pom.xml
@@ -19,7 +19,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.11</version>
 				<configuration>
 					<argLine>-Xmx1600M</argLine>
 				</configuration>

--- a/OWLTools-Annotation/src/main/java/owltools/gaf/io/OpenAnnotationRDFWriter.java
+++ b/OWLTools-Annotation/src/main/java/owltools/gaf/io/OpenAnnotationRDFWriter.java
@@ -16,15 +16,15 @@ import owltools.gaf.GafDocument;
 import owltools.gaf.GeneAnnotation;
 import owltools.vocab.OBOUpperVocabulary;
 
-import com.hp.hpl.jena.datatypes.xsd.XSDDatatype;
-import com.hp.hpl.jena.rdf.model.Literal;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.vocabulary.RDF;
-import com.hp.hpl.jena.vocabulary.RDFS;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
 
 /**
  * Generates and writes RDF Models conforming to http://www.openannotation.org/spec/core/core.html

--- a/OWLTools-Core/pom.xml
+++ b/OWLTools-Core/pom.xml
@@ -16,7 +16,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/OWLTools-Core/pom.xml
+++ b/OWLTools-Core/pom.xml
@@ -103,10 +103,6 @@
 			<artifactId>gson</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>jline</groupId>
-			<artifactId>jline</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.geneontology</groupId>
 			<artifactId>expression-materializing-reasoner</artifactId>
 		</dependency>
@@ -118,7 +114,7 @@
 		<dependency>
 			<groupId>org.geneontology</groupId>
 			<artifactId>obographs</artifactId>
-			<version>0.1.0</version>
+			<version>0.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/OWLTools-NCBI/pom.xml
+++ b/OWLTools-NCBI/pom.xml
@@ -47,7 +47,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<configuration>
 					<links>
-						<link>http://owlapi.sourceforge.net/javadoc/</link>
+						<link>http://owlcs.github.io/owlapi/apidocs_4/</link>
 					</links>
 				</configuration>
 			</plugin>

--- a/OWLTools-Parent/pom.xml
+++ b/OWLTools-Parent/pom.xml
@@ -264,7 +264,7 @@
 			<dependency>
 				<groupId>org.apache.jena</groupId>
 				<artifactId>jena-core</artifactId>
-				<version>2.11.2</version>
+				<version>3.14.0</version>
 			</dependency>
 			<dependency>
 				<groupId>net.sf.trove4j</groupId>

--- a/OWLTools-Parent/pom.xml
+++ b/OWLTools-Parent/pom.xml
@@ -27,7 +27,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -49,9 +49,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>3.2.0</version>
 				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
+					<doclint>none</doclint>
+					<source>1.8</source> <!-- Allows packaging on Java 11 -->
 				</configuration>
 				<executions>
 					<execution>
@@ -77,7 +78,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<argLine>-Xmx2200M</argLine>
 				</configuration>
@@ -85,7 +86,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>versions-maven-plugin</artifactId>
-				<version>2.1</version>
+				<version>2.7</version>
 			</plugin>
 		</plugins>
 		<pluginManagement>
@@ -93,12 +94,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>2.4.3</version>
+					<version>3.2.3</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/OWLTools-Parent/pom.xml
+++ b/OWLTools-Parent/pom.xml
@@ -18,8 +18,8 @@
 	</issueManagement>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<owlapi.version>4.5.6</owlapi.version>
-		<slf4j.version>1.7.10</slf4j.version>
+		<owlapi.version>4.5.6</owlapi.version> <!-- Needs fix to upgrade to 4.5.16; see failing test-->
+		<slf4j.version>1.7.30</slf4j.version>
 	</properties>
 
 	<build>
@@ -131,7 +131,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -173,7 +173,7 @@
 			<dependency>
 				<groupId>net.sourceforge.owlapi</groupId>
 				<artifactId>org.semanticweb.hermit</artifactId>
-				<version>1.3.8.413</version>
+				<version>1.4.5.456</version>
 			</dependency>
 			<dependency>
 				<groupId>org.bbop</groupId>
@@ -188,7 +188,7 @@
 			<dependency>
 				<groupId>org.apache.ant</groupId>
 				<artifactId>ant</artifactId>
-				<version>1.8.2</version>
+				<version>1.10.7</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
@@ -209,22 +209,22 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.2</version>
+				<version>2.6</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1-fixit</version> <!-- This version does not contain a zero day exploit class InvokeTransformer -->
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.1</version>
+				<version>3.10</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-math3</artifactId>
-				<version>3.3</version>
+				<version>3.6.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.semanticweb.elk</groupId>
@@ -234,23 +234,12 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.2.4</version>
+				<version>2.8.6</version>
 			</dependency>
 			<dependency>
 				<groupId>rhino</groupId>
 				<artifactId>js</artifactId>
 				<version>1.7R2</version>
-			</dependency>
-			<dependency>
-				<groupId>jline</groupId>
-				<artifactId>jline</artifactId>
-				<version>0.9.93</version>
-				<exclusions>
-					<exclusion>
-						<groupId>junit</groupId>
-						<artifactId>junit</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.geneontology</groupId>
@@ -270,7 +259,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>18.0</version>
+				<version>29.0-jre</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.jena</groupId>

--- a/OWLTools-Runner/pom.xml
+++ b/OWLTools-Runner/pom.xml
@@ -20,7 +20,7 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.1.13</version>
+				<version>4.0.0</version>
 				<executions>
 					<execution>
 						<id>git-commit-id</id>
@@ -71,7 +71,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.skife.maven</groupId>
 				<artifactId>really-executable-jar-maven-plugin</artifactId>
-				<version>1.4.1</version>
+				<version>1.5.0</version>
                 <executions>
                     <execution>
                         <id>owltools</id>
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>copy-owltools</id>

--- a/OWLTools-Sim/pom.xml
+++ b/OWLTools-Sim/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>com.googlecode.javaewah</groupId>
 			<artifactId>JavaEWAH</artifactId>
-			<version>0.7.7</version>
+			<version>1.1.7</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/OWLTools-Sim/src/main/java/owltools/sim2/FastOwlSim.java
+++ b/OWLTools-Sim/src/main/java/owltools/sim2/FastOwlSim.java
@@ -41,6 +41,8 @@ import owltools.sim2.scores.ScoreMatrix;
 import com.googlecode.javaewah.EWAHCompressedBitmap;
 import com.googlecode.javaewah.IntIterator;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Faster implementation of OwlSim
  * 
@@ -2102,7 +2104,7 @@ public class FastOwlSim extends AbstractOwlSim implements OwlSim {
 
 		FileInputStream s = new FileInputStream(fileName);
 		//List<String> lines = IOUtils.readLines(s);
-		LineIterator itr = IOUtils.lineIterator(s, null);
+		LineIterator itr = IOUtils.lineIterator(s, UTF_8);
 		while (itr.hasNext()) {
 			String line = itr.nextLine();
 			String[] vals = line.split("\t");

--- a/OWLTools-Solr/pom.xml
+++ b/OWLTools-Solr/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<artifactId>solr-solrj</artifactId>
 			<groupId>org.apache.solr</groupId>
-			<version>3.6.0</version>
+			<version>3.6.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.10</version>
+			<version>1.26</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
I updated nearly all dependencies, including Maven plugins. This fixes #292, and should fix #290. owltools can now be packaged when running Java 11. Things I did not update:
- OWL API — there is an issue with some oboformat manipulation that owltools is doing when running with OWL API 4.5.16.
- Jetty — the current version isn't compatible without fixing some code. Does anyone use the owltools Jetty server?
